### PR TITLE
Fix: MobProvider link problem

### DIFF
--- a/src/main/java/kinoko/provider/MobProvider.java
+++ b/src/main/java/kinoko/provider/MobProvider.java
@@ -45,6 +45,7 @@ public final class MobProvider implements WzProvider {
             }
             if (infoProp.getItems().containsKey("link")) {
                 linkedMobs.put(mobId, Tuple.of(WzProvider.getInteger(infoProp.get("link")), infoProp));
+                mobProperties.put(mobId, mobProperty);
                 continue;
             }
             mobProperties.put(mobId, mobProperty);


### PR DESCRIPTION
it will error when mobA link mobB, and mobB link mobC in Mob.wz

error in line 60
```
if (linkProp == null) {
    throw new ProviderError("Failed to resolve linked mob ID : %d, link : %d", mobId, link);
}
```