### PR TITLE
Remove locks from field objects

### DIFF
--- a/src/main/java/kinoko/handler/field/FieldHandler.java
+++ b/src/main/java/kinoko/handler/field/FieldHandler.java
@@ -48,10 +48,8 @@ public final class FieldHandler {
         }
 
         // Pick up drop
-        try (var locked = user.acquire()) {
-            field.getDropPool().pickUpDrop(locked, dropResult.get(), DropLeaveType.PICKED_UP_BY_USER, 0);
-            user.dispose();
-        }
+        field.getDropPool().pickUpDrop(user, dropResult.get(), DropLeaveType.PICKED_UP_BY_USER, 0);
+        user.dispose();
     }
 
 
@@ -71,19 +69,17 @@ public final class FieldHandler {
             log.error("Received ReactorHit for invalid object with ID : {}", objectId);
             return;
         }
-        try (var lockedReactor = reactorResult.get().acquire()) {
-            // Hit reactor
-            final Reactor reactor = lockedReactor.get();
-            if (reactor.isNotHitable()) {
-                log.error("{} : tried to hit reactor that is not hitable", reactor);
-                return;
-            }
-            if (!reactor.tryHit(skillId)) {
-                log.error("{} : could not hit reactor with skill ID {}", reactor, skillId);
-                return;
-            }
-            field.getReactorPool().hitReactor(user, reactor, delay);
+        // Hit reactor
+        final Reactor reactor = reactorResult.get();
+        if (reactor.isNotHitable()) {
+            log.error("{} : tried to hit reactor that is not hitable", reactor);
+            return;
         }
+        if (!reactor.tryHit(skillId)) {
+            log.error("{} : could not hit reactor with skill ID {}", reactor, skillId);
+            return;
+        }
+        field.getReactorPool().hitReactor(user, reactor, delay);
     }
 
     @Handler(InHeader.ReactorTouch)
@@ -97,16 +93,14 @@ public final class FieldHandler {
             log.error("Received ReactorTouch for invalid object with ID : {}", objectId);
             return;
         }
-        try (var lockedReactor = reactorResult.get().acquire()) {
-            // Hit reactor
-            final Reactor reactor = lockedReactor.get();
-            if (!reactor.isActivateByTouch()) {
-                log.error("{} : tried to hit reactor that is not activated by touch", reactor);
-                return;
-            }
-            // There are no reactors activated by touch in v95
-            log.error(String.format("Unexpected reactor touch received for %s", reactor));
+        // Hit reactor
+        final Reactor reactor = reactorResult.get();
+        if (!reactor.isActivateByTouch()) {
+            log.error("{} : tried to hit reactor that is not activated by touch", reactor);
+            return;
         }
+        // There are no reactors activated by touch in v95
+        log.error(String.format("Unexpected reactor touch received for %s", reactor));
     }
 
     @Handler(InHeader.RequireFieldObstacleStatus)

--- a/src/main/java/kinoko/handler/user/UserHandler.java
+++ b/src/main/java/kinoko/handler/user/UserHandler.java
@@ -34,7 +34,6 @@ import kinoko.server.memo.MemoRequestType;
 import kinoko.server.memo.MemoType;
 import kinoko.server.messenger.MessengerProtocol;
 import kinoko.server.messenger.MessengerRequest;
-import kinoko.server.node.ServerExecutor;
 import kinoko.server.packet.InPacket;
 import kinoko.server.rank.RankManager;
 import kinoko.server.user.RemoteUser;
@@ -1664,10 +1663,8 @@ public final class UserHandler {
             }
             case Load -> {
                 // CWvsContext::OnMemoNotify_Receive
-                ServerExecutor.submitService(() -> {
-                    final List<Memo> memos = DatabaseManager.memoAccessor().getMemosByCharacterId(user.getCharacterId());
-                    user.write(MemoPacket.load(memos));
-                });
+                final List<Memo> memos = DatabaseManager.memoAccessor().getMemosByCharacterId(user.getCharacterId());
+                user.write(MemoPacket.load(memos));
             }
             case null -> {
                 log.error("Unknown memo request type : {}", type);

--- a/src/main/java/kinoko/handler/user/UserHandler.java
+++ b/src/main/java/kinoko/handler/user/UserHandler.java
@@ -1690,15 +1690,7 @@ public final class UserHandler {
         if (townPortal.getTownField() == user.getField()) {
             user.warp(townPortal.getField(), townPortal.getX(), townPortal.getY(), townPortalId, false, false);
         } else {
-            final int x, y;
-            final Optional<PortalInfo> portalPointResult = townPortal.getTownPortalPoint();
-            if (portalPointResult.isPresent()) {
-                x = portalPointResult.get().getX();
-                y = portalPointResult.get().getY();
-            } else {
-                x = y = 0;
-            }
-            user.warp(townPortal.getTownField(), x, y, townPortalId, false, false);
+            user.warp(townPortal.getTownField(), townPortal.getTownPortalPoint().orElse(PortalInfo.EMPTY), false, false);
         }
     }
 

--- a/src/main/java/kinoko/handler/user/UserHandler.java
+++ b/src/main/java/kinoko/handler/user/UserHandler.java
@@ -190,23 +190,18 @@ public final class UserHandler {
             return;
         }
         // Handle trunk / npc shop dialog, lock user
-        try (var locked = user.acquire()) {
-            if (user.hasDialog()) {
-                log.error("Tried to select npc ID {}, while already in a dialog", npc.getTemplateId());
-                return;
-            }
-            if (npc.isTrunk()) {
-                final TrunkDialog trunkDialog = TrunkDialog.from(npc.getTemplate());
-                user.setDialog(trunkDialog);
-                // Lock account to access trunk
-                try (var lockedAccount = user.getAccount().acquire()) {
-                    user.write(TrunkPacket.openTrunkDlg(npc.getTemplateId(), lockedAccount.get().getTrunk()));
-                }
-            } else if (ShopProvider.isShop(npc.getTemplateId())) {
-                final ShopDialog shopDialog = ShopDialog.from(npc.getTemplate());
-                user.setDialog(shopDialog);
-                user.write(FieldPacket.openShopDlg(user, shopDialog));
-            }
+        if (user.hasDialog()) {
+            log.error("Tried to select npc ID {}, while already in a dialog", npc.getTemplateId());
+            return;
+        }
+        if (npc.isTrunk()) {
+            final TrunkDialog trunkDialog = TrunkDialog.from(npc.getTemplate());
+            user.setDialog(trunkDialog);
+            user.write(TrunkPacket.openTrunkDlg(npc.getTemplateId(), user.getAccount().getTrunk()));
+        } else if (ShopProvider.isShop(npc.getTemplateId())) {
+            final ShopDialog shopDialog = ShopDialog.from(npc.getTemplate());
+            user.setDialog(shopDialog);
+            user.write(FieldPacket.openShopDlg(user, shopDialog));
         }
     }
 
@@ -219,66 +214,60 @@ public final class UserHandler {
             log.error("Unknown script message type {}", type);
             return;
         }
-        try (var locked = user.acquire()) {
-            if (!user.hasDialog() || !(user.getDialog() instanceof ScriptDialog scriptDialog)) {
-                log.error("Received UserScriptMessageAnswer without an associated script dialog");
-                return;
+        if (!user.hasDialog() || !(user.getDialog() instanceof ScriptDialog scriptDialog)) {
+            log.error("Received UserScriptMessageAnswer without an associated script dialog");
+            return;
+        }
+        switch (lastMessageType) {
+            case SAY, SAYIMAGE, ASKYESNO, ASKACCEPT -> {
+                scriptDialog.submitAnswer(ScriptAnswer.withAction(action));
             }
-            switch (lastMessageType) {
-                case SAY, SAYIMAGE, ASKYESNO, ASKACCEPT -> {
-                    scriptDialog.submitAnswer(ScriptAnswer.withAction(action));
+            case ASKTEXT, ASKBOXTEXT -> {
+                if (action == 1) {
+                    final String answer = inPacket.decodeString(); // sInputStr_Result
+                    scriptDialog.submitAnswer(ScriptAnswer.withTextAnswer(action, answer));
+                } else {
+                    scriptDialog.submitAnswer(ScriptAnswer.withAction(-1));
                 }
-                case ASKTEXT, ASKBOXTEXT -> {
-                    if (action == 1) {
-                        final String answer = inPacket.decodeString(); // sInputStr_Result
-                        scriptDialog.submitAnswer(ScriptAnswer.withTextAnswer(action, answer));
-                    } else {
-                        scriptDialog.submitAnswer(ScriptAnswer.withAction(-1));
-                    }
+            }
+            case ASKNUMBER, ASKMENU, ASKSLIDEMENU -> {
+                if (action == 1) {
+                    final int answer = inPacket.decodeInt(); // nInputNo_Result | nSelect
+                    scriptDialog.submitAnswer(ScriptAnswer.withAnswer(action, answer));
+                } else {
+                    scriptDialog.submitAnswer(ScriptAnswer.withAction(-1));
                 }
-                case ASKNUMBER, ASKMENU, ASKSLIDEMENU -> {
-                    if (action == 1) {
-                        final int answer = inPacket.decodeInt(); // nInputNo_Result | nSelect
-                        scriptDialog.submitAnswer(ScriptAnswer.withAnswer(action, answer));
-                    } else {
-                        scriptDialog.submitAnswer(ScriptAnswer.withAction(-1));
-                    }
+            }
+            case ASKAVATAR, ASKMEMBERSHOPAVATAR -> {
+                if (action == 1) {
+                    final byte answer = inPacket.decodeByte(); // nAvatarIndex
+                    scriptDialog.submitAnswer(ScriptAnswer.withAnswer(action, answer));
+                } else {
+                    scriptDialog.submitAnswer(ScriptAnswer.withAction(-1));
                 }
-                case ASKAVATAR, ASKMEMBERSHOPAVATAR -> {
-                    if (action == 1) {
-                        final byte answer = inPacket.decodeByte(); // nAvatarIndex
-                        scriptDialog.submitAnswer(ScriptAnswer.withAnswer(action, answer));
-                    } else {
-                        scriptDialog.submitAnswer(ScriptAnswer.withAction(-1));
-                    }
-                }
-                default -> {
-                    log.error("Unhandled script message type {}", lastMessageType);
-                }
+            }
+            default -> {
+                log.error("Unhandled script message type {}", lastMessageType);
             }
         }
     }
 
     @Handler(InHeader.UserShopRequest)
     public static void handleUserShopRequest(User user, InPacket inPacket) {
-        try (var locked = user.acquire()) {
-            if (!(user.getDialog() instanceof ShopDialog shopDialog)) {
-                log.error("Received UserShopRequest without associated shop dialog");
-                return;
-            }
-            shopDialog.handlePacket(locked, inPacket);
+        if (!(user.getDialog() instanceof ShopDialog shopDialog)) {
+            log.error("Received UserShopRequest without associated shop dialog");
+            return;
         }
+        shopDialog.handlePacket(user, inPacket);
     }
 
     @Handler(InHeader.UserTrunkRequest)
     public static void handleUserTrunkRequest(User user, InPacket inPacket) {
-        try (var locked = user.acquire()) {
-            if (!(user.getDialog() instanceof TrunkDialog trunkDialog)) {
-                log.error("Received UserTrunkRequest without associated trunk dialog");
-                return;
-            }
-            trunkDialog.handlePacket(locked, inPacket);
+        if (!(user.getDialog() instanceof TrunkDialog trunkDialog)) {
+            log.error("Received UserTrunkRequest without associated trunk dialog");
+            return;
         }
+        trunkDialog.handlePacket(user, inPacket);
     }
 
 
@@ -292,59 +281,57 @@ public final class UserHandler {
             user.dispose();
             return;
         }
-        try (var locked = user.acquire()) {
-            final InventoryManager im = user.getInventoryManager();
-            final Inventory inventory = im.getInventoryByType(inventoryType);
-            // Find stackable items : itemId -> Set<Tuple<position, item>>
-            final Map<Integer, List<Tuple<Integer, Item>>> stackable = new HashMap<>();
-            for (var entry : inventory.getItems().entrySet()) {
-                final int position = entry.getKey();
-                final Item item = entry.getValue();
-                if (item.getItemType() != ItemType.BUNDLE || ItemConstants.isRechargeableItem(item.getItemId())) {
-                    continue;
-                }
-                final Optional<ItemInfo> itemInfoResult = ItemProvider.getItemInfo(item.getItemId());
-                if (itemInfoResult.isEmpty() || itemInfoResult.get().getSlotMax() <= 1) {
-                    continue;
-                }
-                if (!stackable.containsKey(item.getItemId())) {
-                    stackable.put(item.getItemId(), new ArrayList<>());
-                }
-                stackable.get(item.getItemId()).add(Tuple.of(position, item));
+        final InventoryManager im = user.getInventoryManager();
+        final Inventory inventory = im.getInventoryByType(inventoryType);
+        // Find stackable items : itemId -> Set<Tuple<position, item>>
+        final Map<Integer, List<Tuple<Integer, Item>>> stackable = new HashMap<>();
+        for (var entry : inventory.getItems().entrySet()) {
+            final int position = entry.getKey();
+            final Item item = entry.getValue();
+            if (item.getItemType() != ItemType.BUNDLE || ItemConstants.isRechargeableItem(item.getItemId())) {
+                continue;
             }
-            // Get required inventory operations
-            final List<InventoryOperation> inventoryOperations = new ArrayList<>();
-            for (var entry : stackable.entrySet()) {
-                if (entry.getValue().size() <= 1) {
-                    continue;
-                }
-                final int slotMax = ItemProvider.getItemInfo(entry.getKey()).map(ItemInfo::getSlotMax).orElse(0);
-                final List<Tuple<Integer, Item>> sortedItems = entry.getValue().stream()
-                        .sorted(Comparator.comparingInt(Tuple::getLeft))
-                        .toList();
-                int total = sortedItems.stream()
-                        .mapToInt((tuple) -> tuple.getRight().getQuantity())
-                        .sum();
-                for (var tuple : sortedItems) {
-                    final int position = tuple.getLeft();
-                    if (total > slotMax) {
-                        inventoryOperations.add(InventoryOperation.itemNumber(inventoryType, position, slotMax));
-                        total -= slotMax;
+            final Optional<ItemInfo> itemInfoResult = ItemProvider.getItemInfo(item.getItemId());
+            if (itemInfoResult.isEmpty() || itemInfoResult.get().getSlotMax() <= 1) {
+                continue;
+            }
+            if (!stackable.containsKey(item.getItemId())) {
+                stackable.put(item.getItemId(), new ArrayList<>());
+            }
+            stackable.get(item.getItemId()).add(Tuple.of(position, item));
+        }
+        // Get required inventory operations
+        final List<InventoryOperation> inventoryOperations = new ArrayList<>();
+        for (var entry : stackable.entrySet()) {
+            if (entry.getValue().size() <= 1) {
+                continue;
+            }
+            final int slotMax = ItemProvider.getItemInfo(entry.getKey()).map(ItemInfo::getSlotMax).orElse(0);
+            final List<Tuple<Integer, Item>> sortedItems = entry.getValue().stream()
+                    .sorted(Comparator.comparingInt(Tuple::getLeft))
+                    .toList();
+            int total = sortedItems.stream()
+                    .mapToInt((tuple) -> tuple.getRight().getQuantity())
+                    .sum();
+            for (var tuple : sortedItems) {
+                final int position = tuple.getLeft();
+                if (total > slotMax) {
+                    inventoryOperations.add(InventoryOperation.itemNumber(inventoryType, position, slotMax));
+                    total -= slotMax;
+                } else {
+                    if (total > 0) {
+                        inventoryOperations.add(InventoryOperation.itemNumber(inventoryType, position, total));
+                        total = 0;
                     } else {
-                        if (total > 0) {
-                            inventoryOperations.add(InventoryOperation.itemNumber(inventoryType, position, total));
-                            total = 0;
-                        } else {
-                            inventoryOperations.add(InventoryOperation.delItem(inventoryType, position));
-                        }
+                        inventoryOperations.add(InventoryOperation.delItem(inventoryType, position));
                     }
                 }
             }
-            // Apply inventory operations and update client
-            im.applyInventoryOperations(inventoryOperations);
-            user.write(WvsContext.inventoryOperation(inventoryOperations, true));
-            user.write(WvsContext.gatherItemResult(inventoryType));
         }
+        // Apply inventory operations and update client
+        im.applyInventoryOperations(inventoryOperations);
+        user.write(WvsContext.inventoryOperation(inventoryOperations, true));
+        user.write(WvsContext.gatherItemResult(inventoryType));
     }
 
     @Handler(InHeader.UserSortItemRequest)
@@ -355,40 +342,38 @@ public final class UserHandler {
             user.dispose();
             return;
         }
-        try (var locked = user.acquire()) {
-            final InventoryManager im = user.getInventoryManager();
-            // Create array for sorting
-            final Item[] items = new Item[GameConstants.INVENTORY_SLOT_MAX]; // using 0-based indexing for positions (inventory uses 1-based)
-            for (var entry : im.getInventoryByType(inventoryType).getItems().entrySet()) {
-                items[entry.getKey() - 1] = entry.getValue();
-            }
-            // Selection sort to find required swaps
-            final List<InventoryOperation> inventoryOperations = new ArrayList<>();
-            for (int i = 0; i < items.length - 1; i++) {
-                int k = i; // minimum index
-                for (int j = i + 1; j < items.length; j++) {
-                    if (items[j] == null) {
-                        continue;
-                    }
-                    // Consolidate, sorting by ID (increasing) and quantity (decreasing)
-                    if (items[k] == null ||
-                            items[j].getItemId() < items[k].getItemId() ||
-                            (items[j].getItemId() == items[k].getItemId() &&
-                                    items[j].getQuantity() > items[k].getQuantity())) {
-                        k = j;
-                    }
-                }
-                // Perform swap
-                final Item temp = items[k];
-                items[k] = items[i];
-                items[i] = temp;
-                inventoryOperations.add(InventoryOperation.position(inventoryType, k + 1, i + 1)); // again, inventory uses 1-based positions
-            }
-            // Apply inventory operations and update client
-            im.applyInventoryOperations(inventoryOperations);
-            user.write(WvsContext.inventoryOperation(inventoryOperations, true));
-            user.write(WvsContext.sortItemResult(inventoryType));
+        final InventoryManager im = user.getInventoryManager();
+        // Create array for sorting
+        final Item[] items = new Item[GameConstants.INVENTORY_SLOT_MAX]; // using 0-based indexing for positions (inventory uses 1-based)
+        for (var entry : im.getInventoryByType(inventoryType).getItems().entrySet()) {
+            items[entry.getKey() - 1] = entry.getValue();
         }
+        // Selection sort to find required swaps
+        final List<InventoryOperation> inventoryOperations = new ArrayList<>();
+        for (int i = 0; i < items.length - 1; i++) {
+            int k = i; // minimum index
+            for (int j = i + 1; j < items.length; j++) {
+                if (items[j] == null) {
+                    continue;
+                }
+                // Consolidate, sorting by ID (increasing) and quantity (decreasing)
+                if (items[k] == null ||
+                        items[j].getItemId() < items[k].getItemId() ||
+                        (items[j].getItemId() == items[k].getItemId() &&
+                                items[j].getQuantity() > items[k].getQuantity())) {
+                    k = j;
+                }
+            }
+            // Perform swap
+            final Item temp = items[k];
+            items[k] = items[i];
+            items[i] = temp;
+            inventoryOperations.add(InventoryOperation.position(inventoryType, k + 1, i + 1)); // again, inventory uses 1-based positions
+        }
+        // Apply inventory operations and update client
+        im.applyInventoryOperations(inventoryOperations);
+        user.write(WvsContext.inventoryOperation(inventoryOperations, true));
+        user.write(WvsContext.sortItemResult(inventoryType));
     }
 
     @Handler(InHeader.UserChangeSlotPositionRequest)
@@ -404,102 +389,100 @@ public final class UserHandler {
         final short newPos = inPacket.decodeShort(); // nNewPos
         final short count = inPacket.decodeShort(); // nCount
 
-        try (var locked = user.acquire()) {
-            final InventoryManager im = locked.get().getInventoryManager();
-            final Inventory inventory = im.getInventoryByType(InventoryType.getByPosition(inventoryType, oldPos));
-            final Item item = inventory.getItem(oldPos);
-            if (item == null) {
-                log.error("Could not find item in {} inventory, position {}", inventoryType.name(), oldPos);
-                return;
-            }
-            final Optional<ItemInfo> itemInfoResult = ItemProvider.getItemInfo(item.getItemId());
-            if (itemInfoResult.isEmpty()) {
-                log.error("Could not resolve item info for item ID : {}, position {}", item.getItemId(), oldPos);
-                return;
-            }
-            final ItemInfo itemInfo = itemInfoResult.get();
-            if (newPos == 0) {
-                // CDraggableItem::ThrowItem - item is deleted if (binded || quest || tradeBlock) && POSSIBLE_TRADING attribute not set
-                final DropEnterType dropEnterType = ((item.hasAttribute(ItemAttribute.EQUIP_BINDED) || itemInfo.isQuest() || itemInfo.isTradeBlock()) && !item.isPossibleTrading()) ?
-                        DropEnterType.FADING_OUT :
-                        DropEnterType.CREATE;
-                if (item.getItemType() == ItemType.BUNDLE && !ItemConstants.isRechargeableItem(item.getItemId()) &&
-                        item.getQuantity() > count) {
-                    // Update item count
-                    item.setQuantity((short) (item.getQuantity() - count));
-                    user.write(WvsContext.inventoryOperation(InventoryOperation.itemNumber(inventoryType, oldPos, item.getQuantity()), true));
-                    // Create partial item
-                    final Item partialItem = new Item(item);
-                    partialItem.setItemSn(user.getNextItemSn());
-                    partialItem.setQuantity(count);
-                    partialItem.setPossibleTrading(false);
-                    // Create drop
-                    final Drop drop = Drop.item(DropOwnType.NOOWN, user, partialItem, user.getCharacterId());
-                    user.getField().getDropPool().addDrop(drop, dropEnterType, user.getX(), user.getY() - GameConstants.DROP_HEIGHT, 0);
-                } else {
-                    // Full drop
-                    if (!inventory.removeItem(oldPos, item)) {
-                        log.error("Failed to remove item in {} inventory, position {}", inventoryType.name(), oldPos);
-                        return;
-                    }
-                    // Remove item from client inventory
-                    user.write(WvsContext.inventoryOperation(InventoryOperation.delItem(inventoryType, oldPos), true));
-                    item.setPossibleTrading(false);
-                    // Create drop
-                    final Drop drop = Drop.item(DropOwnType.NOOWN, user, item, user.getCharacterId());
-                    user.getField().getDropPool().addDrop(drop, dropEnterType, user.getX(), user.getY() - GameConstants.DROP_HEIGHT, 0);
-                }
+        final InventoryManager im = user.getInventoryManager();
+        final Inventory inventory = im.getInventoryByType(InventoryType.getByPosition(inventoryType, oldPos));
+        final Item item = inventory.getItem(oldPos);
+        if (item == null) {
+            log.error("Could not find item in {} inventory, position {}", inventoryType.name(), oldPos);
+            return;
+        }
+        final Optional<ItemInfo> itemInfoResult = ItemProvider.getItemInfo(item.getItemId());
+        if (itemInfoResult.isEmpty()) {
+            log.error("Could not resolve item info for item ID : {}, position {}", item.getItemId(), oldPos);
+            return;
+        }
+        final ItemInfo itemInfo = itemInfoResult.get();
+        if (newPos == 0) {
+            // CDraggableItem::ThrowItem - item is deleted if (binded || quest || tradeBlock) && POSSIBLE_TRADING attribute not set
+            final DropEnterType dropEnterType = ((item.hasAttribute(ItemAttribute.EQUIP_BINDED) || itemInfo.isQuest() || itemInfo.isTradeBlock()) && !item.isPossibleTrading()) ?
+                    DropEnterType.FADING_OUT :
+                    DropEnterType.CREATE;
+            if (item.getItemType() == ItemType.BUNDLE && !ItemConstants.isRechargeableItem(item.getItemId()) &&
+                    item.getQuantity() > count) {
+                // Update item count
+                item.setQuantity((short) (item.getQuantity() - count));
+                user.write(WvsContext.inventoryOperation(InventoryOperation.itemNumber(inventoryType, oldPos, item.getQuantity()), true));
+                // Create partial item
+                final Item partialItem = new Item(item);
+                partialItem.setItemSn(user.getNextItemSn());
+                partialItem.setQuantity(count);
+                partialItem.setPossibleTrading(false);
+                // Create drop
+                final Drop drop = Drop.item(DropOwnType.NOOWN, user, partialItem, user.getCharacterId());
+                user.getField().getDropPool().addDrop(drop, dropEnterType, user.getX(), user.getY() - GameConstants.DROP_HEIGHT, 0);
             } else {
-                final InventoryType secondInventoryType = InventoryType.getByPosition(inventoryType, newPos);
-                final Inventory secondInventory = im.getInventoryByType(secondInventoryType);
-                if (secondInventoryType == InventoryType.EQUIPPED) {
-                    // Check body part
-                    final int absPos = Math.abs(newPos);
-                    final boolean isCash = absPos >= BodyPart.CASH_BASE.getValue() && absPos < BodyPart.CASH_END.getValue();
-                    final BodyPart bodyPart = BodyPart.getByValue(isCash ? (absPos - BodyPart.CASH_BASE.getValue()) : absPos);
-                    if (bodyPart == null || !ItemConstants.isCorrectBodyPart(item.getItemId(), bodyPart, user.getGender())) {
-                        log.error("Failed to equip item ID {} in position {}", item.getItemId(), absPos);
-                        user.dispose();
-                        return;
-                    }
-                    // Move exclusive body part equip item to inventory
-                    final BodyPart exclusiveBodyPart = ItemConstants.getExclusiveEquipItemBodyPart(secondInventory, item.getItemId(), isCash);
-                    if (exclusiveBodyPart != null) {
-                        final Item exclusiveEquipItem = secondInventory.getItem(exclusiveBodyPart.getValue() + (isCash ? BodyPart.CASH_BASE.getValue() : 0));
-                        final Optional<Integer> availablePositionResult = InventoryManager.getAvailablePosition(im.getEquipInventory());
-                        if (availablePositionResult.isEmpty()) {
-                            log.error("No room in inventory remove exclusive equip item body part item ID {} in position {}", exclusiveEquipItem.getItemId(), exclusiveBodyPart);
-                            user.dispose();
-                            return;
-                        }
-                        final int availablePosition = availablePositionResult.get();
-                        if (!secondInventory.removeItem(exclusiveBodyPart.getValue(), exclusiveEquipItem)) {
-                            throw new IllegalStateException("Could not remove exclusive equip item");
-                        }
-                        im.getEquipInventory().putItem(availablePosition, exclusiveEquipItem);
-                        user.write(WvsContext.inventoryOperation(InventoryOperation.position(InventoryType.EQUIP, -exclusiveBodyPart.getValue(), availablePosition), false)); // client uses negative index for equipped
-                    }
-                    // Handle items binded on equip
-                    if (itemInfo.isEquipTradeBlock() && !item.hasAttribute(ItemAttribute.EQUIP_BINDED)) {
-                        item.addAttribute(ItemAttribute.EQUIP_BINDED);
-                        user.write(WvsContext.inventoryOperation(InventoryOperation.newItem(InventoryType.EQUIP, oldPos, item), false));
-                    }
-                } else if (secondInventory.getSize() < newPos) {
+                // Full drop
+                if (!inventory.removeItem(oldPos, item)) {
+                    log.error("Failed to remove item in {} inventory, position {}", inventoryType.name(), oldPos);
+                    return;
+                }
+                // Remove item from client inventory
+                user.write(WvsContext.inventoryOperation(InventoryOperation.delItem(inventoryType, oldPos), true));
+                item.setPossibleTrading(false);
+                // Create drop
+                final Drop drop = Drop.item(DropOwnType.NOOWN, user, item, user.getCharacterId());
+                user.getField().getDropPool().addDrop(drop, dropEnterType, user.getX(), user.getY() - GameConstants.DROP_HEIGHT, 0);
+            }
+        } else {
+            final InventoryType secondInventoryType = InventoryType.getByPosition(inventoryType, newPos);
+            final Inventory secondInventory = im.getInventoryByType(secondInventoryType);
+            if (secondInventoryType == InventoryType.EQUIPPED) {
+                // Check body part
+                final int absPos = Math.abs(newPos);
+                final boolean isCash = absPos >= BodyPart.CASH_BASE.getValue() && absPos < BodyPart.CASH_END.getValue();
+                final BodyPart bodyPart = BodyPart.getByValue(isCash ? (absPos - BodyPart.CASH_BASE.getValue()) : absPos);
+                if (bodyPart == null || !ItemConstants.isCorrectBodyPart(item.getItemId(), bodyPart, user.getGender())) {
+                    log.error("Failed to equip item ID {} in position {}", item.getItemId(), absPos);
                     user.dispose();
                     return;
                 }
-                // Swap item position and update client
-                final Item secondItem = secondInventory.getItem(newPos);
-                inventory.putItem(oldPos, secondItem);
-                secondInventory.putItem(newPos, item);
-                user.write(WvsContext.inventoryOperation(InventoryOperation.position(inventoryType, oldPos, newPos), true));
+                // Move exclusive body part equip item to inventory
+                final BodyPart exclusiveBodyPart = ItemConstants.getExclusiveEquipItemBodyPart(secondInventory, item.getItemId(), isCash);
+                if (exclusiveBodyPart != null) {
+                    final Item exclusiveEquipItem = secondInventory.getItem(exclusiveBodyPart.getValue() + (isCash ? BodyPart.CASH_BASE.getValue() : 0));
+                    final Optional<Integer> availablePositionResult = InventoryManager.getAvailablePosition(im.getEquipInventory());
+                    if (availablePositionResult.isEmpty()) {
+                        log.error("No room in inventory remove exclusive equip item body part item ID {} in position {}", exclusiveEquipItem.getItemId(), exclusiveBodyPart);
+                        user.dispose();
+                        return;
+                    }
+                    final int availablePosition = availablePositionResult.get();
+                    if (!secondInventory.removeItem(exclusiveBodyPart.getValue(), exclusiveEquipItem)) {
+                        throw new IllegalStateException("Could not remove exclusive equip item");
+                    }
+                    im.getEquipInventory().putItem(availablePosition, exclusiveEquipItem);
+                    user.write(WvsContext.inventoryOperation(InventoryOperation.position(InventoryType.EQUIP, -exclusiveBodyPart.getValue(), availablePosition), false)); // client uses negative index for equipped
+                }
+                // Handle items binded on equip
+                if (itemInfo.isEquipTradeBlock() && !item.hasAttribute(ItemAttribute.EQUIP_BINDED)) {
+                    item.addAttribute(ItemAttribute.EQUIP_BINDED);
+                    user.write(WvsContext.inventoryOperation(InventoryOperation.newItem(InventoryType.EQUIP, oldPos, item), false));
+                }
+            } else if (secondInventory.getSize() < newPos) {
+                user.dispose();
+                return;
             }
-            // Update user
-            if (inventoryType == InventoryType.EQUIP) {
-                user.getCharacterData().getCoupleRecord().reset(im.getEquipped(), im.getEquipInventory());
-                user.validateStat();
-                user.getField().broadcastPacket(UserRemote.avatarModified(user), user);
-            }
+            // Swap item position and update client
+            final Item secondItem = secondInventory.getItem(newPos);
+            inventory.putItem(oldPos, secondItem);
+            secondInventory.putItem(newPos, item);
+            user.write(WvsContext.inventoryOperation(InventoryOperation.position(inventoryType, oldPos, newPos), true));
+        }
+        // Update user
+        if (inventoryType == InventoryType.EQUIP) {
+            user.getCharacterData().getCoupleRecord().reset(im.getEquipped(), im.getEquipInventory());
+            user.validateStat();
+            user.getField().broadcastPacket(UserRemote.avatarModified(user), user);
         }
     }
 
@@ -516,27 +499,25 @@ public final class UserHandler {
             user.dispose();
             return;
         }
-        try (var locked = user.acquire()) {
-            // Validate stat
-            final CharacterStat cs = locked.get().getCharacterStat();
-            if (cs.getAp() < 1) {
-                log.error("Tried to add ap with {} remaining ap", cs.getAp());
-                user.dispose();
-                return;
-            }
-            if (!cs.isValidAp(stat, 1)) {
-                log.error("Tried to add ap to stat {}", stat);
-                user.dispose();
-                return;
-            }
-            // Add stat
-            final Map<Stat, Object> addApResult = cs.addAp(stat, user.getBasicStat().getInt());
-            cs.setAp((short) (cs.getAp() - 1));
-            addApResult.put(Stat.AP, cs.getAp());
-            // Update client
-            user.validateStat();
-            user.write(WvsContext.statChanged(addApResult, true));
+        // Validate stat
+        final CharacterStat cs = user.getCharacterStat();
+        if (cs.getAp() < 1) {
+            log.error("Tried to add ap with {} remaining ap", cs.getAp());
+            user.dispose();
+            return;
         }
+        if (!cs.isValidAp(stat, 1)) {
+            log.error("Tried to add ap to stat {}", stat);
+            user.dispose();
+            return;
+        }
+        // Add stat
+        final Map<Stat, Object> addApResult = cs.addAp(stat, user.getBasicStat().getInt());
+        cs.setAp((short) (cs.getAp() - 1));
+        addApResult.put(Stat.AP, cs.getAp());
+        // Update client
+        user.validateStat();
+        user.write(WvsContext.statChanged(addApResult, true));
     }
 
     @Handler(InHeader.UserAbilityMassUpRequest)
@@ -555,39 +536,37 @@ public final class UserHandler {
             }
             stats.put(stat, value);
         }
-        try (var locked = user.acquire()) {
-            // Validate stats
-            final CharacterStat cs = locked.get().getCharacterStat();
-            final int requiredAp = stats.values().stream().mapToInt(Integer::intValue).sum();
-            if (cs.getAp() < requiredAp) {
-                log.error("Tried to add {} ap with {} remaining ap", requiredAp, cs.getAp());
+        // Validate stats
+        final CharacterStat cs = user.getCharacterStat();
+        final int requiredAp = stats.values().stream().mapToInt(Integer::intValue).sum();
+        if (cs.getAp() < requiredAp) {
+            log.error("Tried to add {} ap with {} remaining ap", requiredAp, cs.getAp());
+            user.dispose();
+            return;
+        }
+        for (var entry : stats.entrySet()) {
+            final Stat stat = entry.getKey();
+            final int value = entry.getValue();
+            if (!cs.isValidAp(stat, value)) {
+                log.error("Tried to add {} ap to stat {}", stat, value);
                 user.dispose();
                 return;
             }
-            for (var entry : stats.entrySet()) {
-                final Stat stat = entry.getKey();
-                final int value = entry.getValue();
-                if (!cs.isValidAp(stat, value)) {
-                    log.error("Tried to add {} ap to stat {}", stat, value);
-                    user.dispose();
-                    return;
-                }
-            }
-            // Add stats
-            final Map<Stat, Object> addApResult = new EnumMap<>(Stat.class);
-            for (var entry : stats.entrySet()) {
-                final Stat stat = entry.getKey();
-                final int value = entry.getValue();
-                for (int i = 0; i < value; i++) {
-                    addApResult.putAll(cs.addAp(stat, user.getBasicStat().getInt()));
-                }
-            }
-            cs.setAp((short) (cs.getAp() - requiredAp));
-            addApResult.put(Stat.AP, cs.getAp());
-            // Update client
-            user.validateStat();
-            user.write(WvsContext.statChanged(addApResult, true));
         }
+        // Add stats
+        final Map<Stat, Object> addApResult = new EnumMap<>(Stat.class);
+        for (var entry : stats.entrySet()) {
+            final Stat stat = entry.getKey();
+            final int value = entry.getValue();
+            for (int i = 0; i < value; i++) {
+                addApResult.putAll(cs.addAp(stat, user.getBasicStat().getInt()));
+            }
+        }
+        cs.setAp((short) (cs.getAp() - requiredAp));
+        addApResult.put(Stat.AP, cs.getAp());
+        // Update client
+        user.validateStat();
+        user.write(WvsContext.statChanged(addApResult, true));
     }
 
     @Handler({ InHeader.UserChangeStatRequest, InHeader.UserChangeStatRequestByItemOption })
@@ -601,13 +580,11 @@ public final class UserHandler {
         final int hp = Short.toUnsignedInt(inPacket.decodeShort()); // nHP
         final int mp = Short.toUnsignedInt(inPacket.decodeShort()); // nMP
         // inPacket.decodeByte(); // nOption for UserChangeStatRequest
-        try (var locked = user.acquire()) {
-            if (hp > 0) {
-                user.addHp(hp);
-            }
-            if (mp > 0) {
-                user.addMp(mp);
-            }
+        if (hp > 0) {
+            user.addHp(hp);
+        }
+        if (mp > 0) {
+            user.addMp(mp);
         }
     }
 
@@ -615,67 +592,65 @@ public final class UserHandler {
     public static void handleUserSkillUpRequest(User user, InPacket inPacket) {
         inPacket.decodeInt(); // update_time
         final int skillId = inPacket.decodeInt(); // nSkillID
-        try (var locked = user.acquire()) {
-            final SkillManager sm = locked.get().getSkillManager();
-            final Optional<SkillRecord> skillRecordResult = sm.getSkill(skillId);
-            if (skillRecordResult.isEmpty()) {
-                log.error("Tried to add a skill {} not owned by user", skillId);
-                user.dispose();
-                return;
-            }
-            final SkillRecord skillRecord = skillRecordResult.get();
-            if (skillRecord.getSkillLevel() >= skillRecord.getMasterLevel()) {
-                log.error("Tried to add a skill {} at master level {}/{}", skillId, skillRecord.getSkillLevel(), skillRecord.getMasterLevel());
-                user.dispose();
-                return;
-            }
-            final int skillRoot = SkillConstants.getSkillRoot(skillId);
-            if (JobConstants.isBeginnerJob(skillRoot)) {
-                // Check if valid beginner skill
-                if (!SkillConstants.isBeginnerSpAddableSkill(skillId)) {
-                    log.error("Tried to add an invalid beginner skill {}", skillId);
-                    user.dispose();
-                    return;
-                }
-                // Compute sp spent on beginner skills
-                final int spentSp = sm.getSkillRecords().stream()
-                        .filter((sr) -> SkillConstants.isBeginnerSpAddableSkill(sr.getSkillId()))
-                        .mapToInt(SkillRecord::getSkillLevel)
-                        .sum();
-                // Beginner sp is calculated by level
-                final int totalSp;
-                if (JobConstants.isResistanceJob(skillRoot)) {
-                    totalSp = Math.min(user.getLevel(), 10) - 1; // max total sp = 9
-                } else {
-                    totalSp = Math.min(user.getLevel(), 7) - 1; // max total sp = 6
-                }
-                // Check if sp can be added
-                if (spentSp >= totalSp) {
-                    log.error("Tried to add skill {} without having the required amount of sp", skillId);
-                    user.dispose();
-                    return;
-                }
-            } else if (JobConstants.isExtendSpJob(skillRoot)) {
-                final int jobLevel = JobConstants.getJobLevel(skillRoot);
-                if (!user.getCharacterStat().getSp().removeSp(jobLevel, 1)) {
-                    log.error("Tried to add skill {} without having the required amount of sp", skillId);
-                    user.dispose();
-                    return;
-                }
-            } else {
-                if (!user.getCharacterStat().getSp().removeNonExtendSp(1)) {
-                    log.error("Tried to add skill {} without having the required amount of sp", skillId);
-                    user.dispose();
-                    return;
-                }
-            }
-            // Add skill point and update client
-            skillRecord.setSkillLevel(skillRecord.getSkillLevel() + 1);
-            user.write(WvsContext.statChanged(Stat.SP, JobConstants.isExtendSpJob(user.getJob()) ? user.getCharacterStat().getSp() : (short) user.getCharacterStat().getSp().getNonExtendSp(), false));
-            user.write(WvsContext.changeSkillRecordResult(skillRecord, true));
-            user.updatePassiveSkillData();
-            user.validateStat();
+        final SkillManager sm = user.getSkillManager();
+        final Optional<SkillRecord> skillRecordResult = sm.getSkill(skillId);
+        if (skillRecordResult.isEmpty()) {
+            log.error("Tried to add a skill {} not owned by user", skillId);
+            user.dispose();
+            return;
         }
+        final SkillRecord skillRecord = skillRecordResult.get();
+        if (skillRecord.getSkillLevel() >= skillRecord.getMasterLevel()) {
+            log.error("Tried to add a skill {} at master level {}/{}", skillId, skillRecord.getSkillLevel(), skillRecord.getMasterLevel());
+            user.dispose();
+            return;
+        }
+        final int skillRoot = SkillConstants.getSkillRoot(skillId);
+        if (JobConstants.isBeginnerJob(skillRoot)) {
+            // Check if valid beginner skill
+            if (!SkillConstants.isBeginnerSpAddableSkill(skillId)) {
+                log.error("Tried to add an invalid beginner skill {}", skillId);
+                user.dispose();
+                return;
+            }
+            // Compute sp spent on beginner skills
+            final int spentSp = sm.getSkillRecords().stream()
+                    .filter((sr) -> SkillConstants.isBeginnerSpAddableSkill(sr.getSkillId()))
+                    .mapToInt(SkillRecord::getSkillLevel)
+                    .sum();
+            // Beginner sp is calculated by level
+            final int totalSp;
+            if (JobConstants.isResistanceJob(skillRoot)) {
+                totalSp = Math.min(user.getLevel(), 10) - 1; // max total sp = 9
+            } else {
+                totalSp = Math.min(user.getLevel(), 7) - 1; // max total sp = 6
+            }
+            // Check if sp can be added
+            if (spentSp >= totalSp) {
+                log.error("Tried to add skill {} without having the required amount of sp", skillId);
+                user.dispose();
+                return;
+            }
+        } else if (JobConstants.isExtendSpJob(skillRoot)) {
+            final int jobLevel = JobConstants.getJobLevel(skillRoot);
+            if (!user.getCharacterStat().getSp().removeSp(jobLevel, 1)) {
+                log.error("Tried to add skill {} without having the required amount of sp", skillId);
+                user.dispose();
+                return;
+            }
+        } else {
+            if (!user.getCharacterStat().getSp().removeNonExtendSp(1)) {
+                log.error("Tried to add skill {} without having the required amount of sp", skillId);
+                user.dispose();
+                return;
+            }
+        }
+        // Add skill point and update client
+        skillRecord.setSkillLevel(skillRecord.getSkillLevel() + 1);
+        user.write(WvsContext.statChanged(Stat.SP, JobConstants.isExtendSpJob(user.getJob()) ? user.getCharacterStat().getSp() : (short) user.getCharacterStat().getSp().getNonExtendSp(), false));
+        user.write(WvsContext.changeSkillRecordResult(skillRecord, true));
+        user.updatePassiveSkillData();
+        user.validateStat();
     }
 
 
@@ -685,16 +660,14 @@ public final class UserHandler {
     public static void handleUserDropMoneyRequest(User user, InPacket inPacket) {
         inPacket.decodeInt(); // update_time
         final int money = inPacket.decodeInt(); // nAmount
-        try (var locked = user.acquire()) {
-            final InventoryManager im = user.getInventoryManager();
-            if (money <= 0 || !im.addMoney(-money)) {
-                user.dispose();
-                return;
-            }
-            final Drop drop = Drop.money(DropOwnType.NOOWN, user, money, user.getCharacterId());
-            user.getField().getDropPool().addDrop(drop, DropEnterType.CREATE, user.getX(), user.getY() - GameConstants.DROP_HEIGHT, 0);
-            user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
+        final InventoryManager im = user.getInventoryManager();
+        if (money <= 0 || !im.addMoney(-money)) {
+            user.dispose();
+            return;
         }
+        final Drop drop = Drop.money(DropOwnType.NOOWN, user, money, user.getCharacterId());
+        user.getField().getDropPool().addDrop(drop, DropEnterType.CREATE, user.getX(), user.getY() - GameConstants.DROP_HEIGHT, 0);
+        user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
     }
 
     @Handler(InHeader.UserCharacterInfoRequest)
@@ -752,27 +725,25 @@ public final class UserHandler {
             return;
         }
         final boolean canTransferContinent = inPacket.decodeBoolean(); // bCanTransferContinent
-        try (var locked = user.acquire()) {
-            final MapTransferInfo mapTransferInfo = locked.get().getMapTransferInfo();
-            if (requestType == MapTransferRequestType.DeleteList) {
-                final int targetField = inPacket.decodeInt(); // dwTargetField
-                if (!mapTransferInfo.delete(targetField, canTransferContinent)) {
-                    log.error("Could not delete field {} from map transfer info", targetField);
-                    return;
-                }
-                user.write(MapTransferPacket.deleteList(mapTransferInfo, canTransferContinent));
-            } else {
-                final Field field = user.getField();
-                if (field.isMapTransferLimit()) {
-                    user.write(MapTransferPacket.registerFail()); // This map is not available to enter for the list.
-                    return;
-                }
-                if (!mapTransferInfo.register(field.getFieldId(), canTransferContinent)) {
-                    log.error("Could not register field {} to map transfer info", field.getFieldId());
-                    return;
-                }
-                user.write(MapTransferPacket.registerList(mapTransferInfo, canTransferContinent));
+        final MapTransferInfo mapTransferInfo = user.getMapTransferInfo();
+        if (requestType == MapTransferRequestType.DeleteList) {
+            final int targetField = inPacket.decodeInt(); // dwTargetField
+            if (!mapTransferInfo.delete(targetField, canTransferContinent)) {
+                log.error("Could not delete field {} from map transfer info", targetField);
+                return;
             }
+            user.write(MapTransferPacket.deleteList(mapTransferInfo, canTransferContinent));
+        } else {
+            final Field field = user.getField();
+            if (field.isMapTransferLimit()) {
+                user.write(MapTransferPacket.registerFail()); // This map is not available to enter for the list.
+                return;
+            }
+            if (!mapTransferInfo.register(field.getFieldId(), canTransferContinent)) {
+                log.error("Could not register field {} to map transfer info", field.getFieldId());
+                return;
+            }
+            user.write(MapTransferPacket.registerList(mapTransferInfo, canTransferContinent));
         }
     }
 
@@ -796,9 +767,7 @@ public final class UserHandler {
                 for (int i = 0; i < size; i++) {
                     lostItems.add(inPacket.decodeInt()); // item id
                 }
-                try (var locked = user.acquire()) {
-                    questInfo.restoreLostItems(locked, lostItems);
-                }
+                questInfo.restoreLostItems(user, lostItems);
             }
             case AcceptQuest -> {
                 final int templateId = inPacket.decodeInt(); // dwNpcTemplateID
@@ -807,17 +776,15 @@ public final class UserHandler {
                     final short x = inPacket.decodeShort(); // ptUserPos.x
                     final short y = inPacket.decodeShort(); // ptUserPos.y
                 }
-                try (var locked = user.acquire()) {
-                    final Optional<QuestRecord> startQuestResult = questInfo.startQuest(locked);
-                    if (startQuestResult.isEmpty()) {
-                        log.error("Failed to accept quest : {}", questId);
-                        user.dispose();
-                        return;
-                    }
-                    user.write(MessagePacket.questRecord(startQuestResult.get()));
-                    user.write(QuestPacket.success(questId, templateId, 0));
-                    user.validateStat();
+                final Optional<QuestRecord> startQuestResult = questInfo.startQuest(user);
+                if (startQuestResult.isEmpty()) {
+                    log.error("Failed to accept quest : {}", questId);
+                    user.dispose();
+                    return;
                 }
+                user.write(MessagePacket.questRecord(startQuestResult.get()));
+                user.write(QuestPacket.success(questId, templateId, 0));
+                user.validateStat();
             }
             case CompleteQuest -> {
                 final int templateId = inPacket.decodeInt(); // dwNpcTemplateID
@@ -827,58 +794,50 @@ public final class UserHandler {
                     final short y = inPacket.decodeShort(); // ptUserPos.y
                 }
                 final int rewardIndex = inPacket.decodeInt(); // nIdx - for selecting reward
-                try (var locked = user.acquire()) {
-                    final Optional<Tuple<QuestRecord, Integer>> questCompleteResult = questInfo.completeQuest(locked, rewardIndex);
-                    if (questCompleteResult.isEmpty()) {
-                        log.error("Failed to complete quest : {}", questId);
-                        user.dispose();
-                        return;
-                    }
-                    final QuestRecord questRecord = questCompleteResult.get().getLeft();
-                    final int nextQuest = questCompleteResult.get().getRight();
-                    user.write(MessagePacket.questRecord(questRecord));
-                    user.write(QuestPacket.success(questId, templateId, nextQuest));
-                    user.validateStat();
+                final Optional<Tuple<QuestRecord, Integer>> questCompleteResult = questInfo.completeQuest(user, rewardIndex);
+                if (questCompleteResult.isEmpty()) {
+                    log.error("Failed to complete quest : {}", questId);
+                    user.dispose();
+                    return;
                 }
+                final QuestRecord questRecord = questCompleteResult.get().getLeft();
+                final int nextQuest = questCompleteResult.get().getRight();
+                user.write(MessagePacket.questRecord(questRecord));
+                user.write(QuestPacket.success(questId, templateId, nextQuest));
+                user.validateStat();
                 // Quest complete effect
                 user.write(UserLocal.effect(Effect.questComplete()));
                 user.getField().broadcastPacket(UserRemote.effect(user, Effect.questComplete()), user);
             }
             case ResignQuest -> {
-                try (var locked = user.acquire()) {
-                    final Optional<QuestRecord> questRecordResult = questInfo.resignQuest(locked);
-                    if (questRecordResult.isEmpty()) {
-                        log.error("Failed to resign quest : {}", questId);
-                        return;
-                    }
-                    user.write(MessagePacket.questRecord(questRecordResult.get()));
-                    user.write(UserLocal.resignQuestReturn(questId));
-                    user.validateStat();
+                final Optional<QuestRecord> questRecordResult = questInfo.resignQuest(user);
+                if (questRecordResult.isEmpty()) {
+                    log.error("Failed to resign quest : {}", questId);
+                    return;
                 }
+                user.write(MessagePacket.questRecord(questRecordResult.get()));
+                user.write(UserLocal.resignQuestReturn(questId));
+                user.validateStat();
             }
             case OpeningScript -> {
                 final int templateId = inPacket.decodeInt(); // dwNpcTemplateID
                 final short x = inPacket.decodeShort(); // ptUserPos.x
                 final short y = inPacket.decodeShort(); // ptUserPos.y
-                try (var locked = user.acquire()) {
-                    if (!questInfo.canStartQuest(locked)) {
-                        log.error("Tried to start opening script for quest {} without meeting requirements", questId);
-                        return;
-                    }
-                    ScriptDispatcher.startQuestScript(user, questId, true, templateId);
+                if (!questInfo.canStartQuest(user)) {
+                    log.error("Tried to start opening script for quest {} without meeting requirements", questId);
+                    return;
                 }
+                ScriptDispatcher.startQuestScript(user, questId, true, templateId);
             }
             case CompleteScript -> {
                 final int templateId = inPacket.decodeInt(); // dwNpcTemplateID
                 final short x = inPacket.decodeShort(); // ptUserPos.x
                 final short y = inPacket.decodeShort(); // ptUserPos.y
-                try (var locked = user.acquire()) {
-                    if (!questInfo.canCompleteQuest(locked)) {
-                        log.error("Tried to start complete script for quest {} without meeting requirements", questId);
-                        return;
-                    }
-                    ScriptDispatcher.startQuestScript(user, questId, false, templateId);
+                if (!questInfo.canCompleteQuest(user)) {
+                    log.error("Tried to start complete script for quest {} without meeting requirements", questId);
+                    return;
                 }
+                ScriptDispatcher.startQuestScript(user, questId, false, templateId);
             }
             case null -> {
                 log.error("Unknown quest action type : {}", action);
@@ -897,9 +856,7 @@ public final class UserHandler {
         for (int i = 0; i < size; i++) {
             macroSysData.add(SingleMacro.decode(inPacket));
         }
-        try (var locked = user.acquire()) {
-            locked.get().getConfigManager().updateMacroSysData(macroSysData);
-        }
+        user.getConfigManager().updateMacroSysData(macroSysData);
     }
 
     @Handler(InHeader.UserItemMakeRequest)
@@ -923,131 +880,128 @@ public final class UserHandler {
                     return;
                 }
                 final ItemMakeInfo itemMakeInfo = itemMakeInfoResult.get();
-                try (var locked = user.acquire()) {
-                    // Check requirements and validate
-                    if (!itemMakeInfo.canCreateItem(locked, catalyst, gems)) {
+                // Check requirements and validate
+                if (!itemMakeInfo.canCreateItem(user, catalyst, gems)) {
+                    user.write(MakerPacket.unknown());
+                    return;
+                }
+                if (!itemMakeInfo.canAddReward(user)) {
+                    user.write(MakerPacket.emptySlot()); // You don't have enough room in your Inventory.
+                    return;
+                }
+                // Resolve reward item
+                final int rewardItemId;
+                final int rewardItemCount;
+                if (itemMakeInfo.getRandomReward().isEmpty()) {
+                    rewardItemId = itemMakeInfo.getItemId();
+                    rewardItemCount = 1;
+                } else {
+                    final Optional<Triple<Integer, Integer, Integer>> rewardResult = Util.getRandomFromCollection(itemMakeInfo.getRandomReward(), Triple::getThird);
+                    if (rewardResult.isEmpty()) {
+                        log.error("Could not resolve maker random reward for item ID : {}", itemId);
                         user.write(MakerPacket.unknown());
                         return;
                     }
-                    if (!itemMakeInfo.canAddReward(locked)) {
-                        user.write(MakerPacket.emptySlot()); // You don't have enough room in your Inventory.
-                        return;
+                    rewardItemId = rewardResult.get().getFirst();
+                    rewardItemCount = rewardResult.get().getSecond();
+                }
+                final Optional<ItemInfo> rewardItemInfoResult = ItemProvider.getItemInfo(rewardItemId);
+                if (rewardItemInfoResult.isEmpty()) {
+                    log.error("Could not resolve item info for item ID : {}", rewardItemId);
+                    user.write(MakerPacket.unknown());
+                    return;
+                }
+                // Deduct cost and items
+                final InventoryManager im = user.getInventoryManager();
+                final int totalCost = MakerConstants.getTotalCostToMake(itemMakeInfo.getCost(), catalyst, gems);
+                if (!im.addMoney(-totalCost)) {
+                    throw new IllegalStateException("Could not deduct total price from user");
+                }
+                final List<Tuple<Integer, Integer>> lostItems = new ArrayList<>(itemMakeInfo.getRecipe());
+                if (catalyst) {
+                    lostItems.add(Tuple.of(itemMakeInfo.getCatalyst(), 1));
+                }
+                for (int gemItemId : gems) {
+                    lostItems.add(Tuple.of(gemItemId, 1));
+                }
+                final List<InventoryOperation> inventoryOperations = new ArrayList<>();
+                for (var tuple : lostItems) {
+                    final Optional<List<InventoryOperation>> removeResult = im.removeItem(tuple.getLeft(), tuple.getRight());
+                    if (removeResult.isEmpty()) {
+                        throw new IllegalStateException("Could not remove item from inventory");
                     }
-                    // Resolve reward item
-                    final int rewardItemId;
-                    final int rewardItemCount;
-                    if (itemMakeInfo.getRandomReward().isEmpty()) {
-                        rewardItemId = itemMakeInfo.getItemId();
-                        rewardItemCount = 1;
-                    } else {
-                        final Optional<Triple<Integer, Integer, Integer>> rewardResult = Util.getRandomFromCollection(itemMakeInfo.getRandomReward(), Triple::getThird);
-                        if (rewardResult.isEmpty()) {
-                            log.error("Could not resolve maker random reward for item ID : {}", itemId);
-                            user.write(MakerPacket.unknown());
-                            return;
-                        }
-                        rewardItemId = rewardResult.get().getFirst();
-                        rewardItemCount = rewardResult.get().getSecond();
-                    }
-                    final Optional<ItemInfo> rewardItemInfoResult = ItemProvider.getItemInfo(rewardItemId);
-                    if (rewardItemInfoResult.isEmpty()) {
-                        log.error("Could not resolve item info for item ID : {}", rewardItemId);
-                        user.write(MakerPacket.unknown());
-                        return;
-                    }
-                    // Deduct cost and items
-                    final InventoryManager im = user.getInventoryManager();
-                    final int totalCost = MakerConstants.getTotalCostToMake(itemMakeInfo.getCost(), catalyst, gems);
-                    if (!im.addMoney(-totalCost)) {
-                        throw new IllegalStateException("Could not deduct total price from user");
-                    }
-                    final List<Tuple<Integer, Integer>> lostItems = new ArrayList<>(itemMakeInfo.getRecipe());
-                    if (catalyst) {
-                        lostItems.add(Tuple.of(itemMakeInfo.getCatalyst(), 1));
-                    }
-                    for (int gemItemId : gems) {
-                        lostItems.add(Tuple.of(gemItemId, 1));
-                    }
-                    final List<InventoryOperation> inventoryOperations = new ArrayList<>();
-                    for (var tuple : lostItems) {
-                        final Optional<List<InventoryOperation>> removeResult = im.removeItem(tuple.getLeft(), tuple.getRight());
-                        if (removeResult.isEmpty()) {
-                            throw new IllegalStateException("Could not remove item from inventory");
-                        }
-                        inventoryOperations.addAll(removeResult.get());
-                    }
-                    // Add reward
-                    final boolean success = !catalyst || Util.succeedProp(90);
-                    if (success) {
-                        final Item rewardItem = rewardItemInfoResult.get().createItem(user.getNextItemSn(), rewardItemCount, catalyst ? ItemVariationOption.NORMAL : ItemVariationOption.NONE);
-                        if (rewardItem.getEquipData() != null) {
-                            final EquipData originalEquipData = new EquipData(rewardItem.getEquipData());
-                            for (int gemItemId : gems) {
-                                final Optional<ItemInfo> gemItemInfoResult = ItemProvider.getItemInfo(gemItemId);
-                                if (gemItemInfoResult.isEmpty()) {
-                                    log.error("Could not resolve item info for item ID : {}", gemItemId);
-                                    continue;
+                    inventoryOperations.addAll(removeResult.get());
+                }
+                // Add reward
+                final boolean success = !catalyst || Util.succeedProp(90);
+                if (success) {
+                    final Item rewardItem = rewardItemInfoResult.get().createItem(user.getNextItemSn(), rewardItemCount, catalyst ? ItemVariationOption.NORMAL : ItemVariationOption.NONE);
+                    if (rewardItem.getEquipData() != null) {
+                        final EquipData originalEquipData = new EquipData(rewardItem.getEquipData());
+                        for (int gemItemId : gems) {
+                            final Optional<ItemInfo> gemItemInfoResult = ItemProvider.getItemInfo(gemItemId);
+                            if (gemItemInfoResult.isEmpty()) {
+                                log.error("Could not resolve item info for item ID : {}", gemItemId);
+                                continue;
+                            }
+                            final ItemInfo gemItemInfo = gemItemInfoResult.get();
+                            if (gemItemInfo.getInfo(ItemInfoType.randOption) != 0) {
+                                // Black Crystal
+                                final int randMax = gemItemInfo.getInfo(ItemInfoType.randOption);
+                                final Map<ItemInfoType, Object> randStats = new EnumMap<>(ItemInfoType.class);
+                                if (originalEquipData.getIncPad() > 0) {
+                                    randStats.put(ItemInfoType.incPAD, Util.getRandom(-randMax, randMax));
                                 }
-                                final ItemInfo gemItemInfo = gemItemInfoResult.get();
-                                if (gemItemInfo.getInfo(ItemInfoType.randOption) != 0) {
-                                    // Black Crystal
-                                    final int randMax = gemItemInfo.getInfo(ItemInfoType.randOption);
-                                    final Map<ItemInfoType, Object> randStats = new EnumMap<>(ItemInfoType.class);
-                                    if (originalEquipData.getIncPad() > 0) {
-                                        randStats.put(ItemInfoType.incPAD, Util.getRandom(-randMax, randMax));
-                                    }
-                                    if (originalEquipData.getIncMad() > 0) {
-                                        randStats.put(ItemInfoType.incMAD, Util.getRandom(-randMax, randMax));
-                                    }
-                                    if (originalEquipData.getIncSpeed() > 0) {
-                                        randStats.put(ItemInfoType.incSpeed, Util.getRandom(-randMax, randMax));
-                                    }
-                                    if (originalEquipData.getIncJump() > 0) {
-                                        randStats.put(ItemInfoType.incJump, Util.getRandom(-randMax, randMax));
-                                    }
-                                    rewardItem.getEquipData().applyScrollStats(randStats);
-                                } else if (gemItemInfo.getInfo(ItemInfoType.randStat) != 0) {
-                                    // Dark Crystal
-                                    final int randMax = gemItemInfo.getInfo(ItemInfoType.randStat);
-                                    final Map<ItemInfoType, Object> randStats = new EnumMap<>(ItemInfoType.class);
-                                    if (originalEquipData.getIncStr() > 0) {
-                                        randStats.put(ItemInfoType.incSTR, Util.getRandom(-randMax, randMax));
-                                    }
-                                    if (originalEquipData.getIncDex() > 0) {
-                                        randStats.put(ItemInfoType.incDEX, Util.getRandom(-randMax, randMax));
-                                    }
-                                    if (originalEquipData.getIncInt() > 0) {
-                                        randStats.put(ItemInfoType.incINT, Util.getRandom(-randMax, randMax));
-                                    }
-                                    if (originalEquipData.getIncLuk() > 0) {
-                                        randStats.put(ItemInfoType.incLUK, Util.getRandom(-randMax, randMax));
-                                    }
-                                    if (originalEquipData.getIncAcc() > 0) {
-                                        randStats.put(ItemInfoType.incACC, Util.getRandom(-randMax, randMax));
-                                    }
-                                    if (originalEquipData.getIncEva() > 0) {
-                                        randStats.put(ItemInfoType.incEVA, Util.getRandom(-randMax, randMax));
-                                    }
-                                    rewardItem.getEquipData().applyScrollStats(randStats);
-                                } else {
-                                    // Other gems
-                                    rewardItem.getEquipData().applyScrollStats(gemItemInfo.getItemInfos());
+                                if (originalEquipData.getIncMad() > 0) {
+                                    randStats.put(ItemInfoType.incMAD, Util.getRandom(-randMax, randMax));
                                 }
+                                if (originalEquipData.getIncSpeed() > 0) {
+                                    randStats.put(ItemInfoType.incSpeed, Util.getRandom(-randMax, randMax));
+                                }
+                                if (originalEquipData.getIncJump() > 0) {
+                                    randStats.put(ItemInfoType.incJump, Util.getRandom(-randMax, randMax));
+                                }
+                                rewardItem.getEquipData().applyScrollStats(randStats);
+                            } else if (gemItemInfo.getInfo(ItemInfoType.randStat) != 0) {
+                                // Dark Crystal
+                                final int randMax = gemItemInfo.getInfo(ItemInfoType.randStat);
+                                final Map<ItemInfoType, Object> randStats = new EnumMap<>(ItemInfoType.class);
+                                if (originalEquipData.getIncStr() > 0) {
+                                    randStats.put(ItemInfoType.incSTR, Util.getRandom(-randMax, randMax));
+                                }
+                                if (originalEquipData.getIncDex() > 0) {
+                                    randStats.put(ItemInfoType.incDEX, Util.getRandom(-randMax, randMax));
+                                }
+                                if (originalEquipData.getIncInt() > 0) {
+                                    randStats.put(ItemInfoType.incINT, Util.getRandom(-randMax, randMax));
+                                }
+                                if (originalEquipData.getIncLuk() > 0) {
+                                    randStats.put(ItemInfoType.incLUK, Util.getRandom(-randMax, randMax));
+                                }
+                                if (originalEquipData.getIncAcc() > 0) {
+                                    randStats.put(ItemInfoType.incACC, Util.getRandom(-randMax, randMax));
+                                }
+                                if (originalEquipData.getIncEva() > 0) {
+                                    randStats.put(ItemInfoType.incEVA, Util.getRandom(-randMax, randMax));
+                                }
+                                rewardItem.getEquipData().applyScrollStats(randStats);
+                            } else {
+                                // Other gems
+                                rewardItem.getEquipData().applyScrollStats(gemItemInfo.getItemInfos());
                             }
                         }
-                        final Optional<List<InventoryOperation>> addResult = im.addItem(rewardItem);
-                        if (addResult.isEmpty()) {
-                            throw new IllegalStateException("Could not add item to inventory");
-                        }
-                        inventoryOperations.addAll(addResult.get());
                     }
-                    // Update client
-                    user.write(WvsContext.inventoryOperation(inventoryOperations, false));
-                    user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
-                    user.write(MakerPacket.normal(success, rewardItemId, rewardItemCount, lostItems, totalCost));
-                    user.write(UserLocal.effect(Effect.itemMaker(success ? MakerResult.SUCCESS : MakerResult.DESTROYED)));
-                    user.getField().broadcastPacket(UserRemote.effect(user, Effect.itemMaker(success ? MakerResult.SUCCESS : MakerResult.DESTROYED)));
+                    final Optional<List<InventoryOperation>> addResult = im.addItem(rewardItem);
+                    if (addResult.isEmpty()) {
+                        throw new IllegalStateException("Could not add item to inventory");
+                    }
+                    inventoryOperations.addAll(addResult.get());
                 }
+                // Update client
+                user.write(WvsContext.inventoryOperation(inventoryOperations, false));
+                user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
+                user.write(MakerPacket.normal(success, rewardItemId, rewardItemCount, lostItems, totalCost));
+                user.write(UserLocal.effect(Effect.itemMaker(success ? MakerResult.SUCCESS : MakerResult.DESTROYED)));
             }
             case MONSTER_CRYSTAL -> {
                 final int itemId = inPacket.decodeInt(); // aRecipeSlot[0].pItem.p->nItemID
@@ -1063,28 +1017,26 @@ public final class UserHandler {
                     user.write(MakerPacket.unknown());
                     return;
                 }
-                try (var locked = user.acquire()) {
-                    final InventoryManager im = locked.get().getInventoryManager();
-                    if (!im.canAddItem(monsterCrystalId, 1)) {
-                        user.write(MakerPacket.emptySlot()); // You don't have enough room in your Inventory.
-                        return;
-                    }
-                    final Optional<List<InventoryOperation>> removeItemResult = im.removeItem(itemId, 100);
-                    if (removeItemResult.isEmpty()) {
-                        user.write(MakerPacket.unknown());
-                        return;
-                    }
-                    final Item item = itemInfoResult.get().createItem(user.getNextItemSn(), 1);
-                    final Optional<List<InventoryOperation>> addItemResult = im.addItem(item);
-                    if (addItemResult.isEmpty()) {
-                        throw new IllegalStateException("Failed to add item to inventory");
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
-                    user.write(WvsContext.inventoryOperation(addItemResult.get(), true));
-                    user.write(MakerPacket.monsterCrystal(monsterCrystalId, itemId));
-                    user.write(UserLocal.effect(Effect.itemMaker(MakerResult.SUCCESS)));
-                    user.getField().broadcastPacket(UserRemote.effect(user, Effect.itemMaker(MakerResult.SUCCESS)));
+                final InventoryManager im = user.getInventoryManager();
+                if (!im.canAddItem(monsterCrystalId, 1)) {
+                    user.write(MakerPacket.emptySlot()); // You don't have enough room in your Inventory.
+                    return;
                 }
+                final Optional<List<InventoryOperation>> removeItemResult = im.removeItem(itemId, 100);
+                if (removeItemResult.isEmpty()) {
+                    user.write(MakerPacket.unknown());
+                    return;
+                }
+                final Item item = itemInfoResult.get().createItem(user.getNextItemSn(), 1);
+                final Optional<List<InventoryOperation>> addItemResult = im.addItem(item);
+                if (addItemResult.isEmpty()) {
+                    throw new IllegalStateException("Failed to add item to inventory");
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
+                user.write(WvsContext.inventoryOperation(addItemResult.get(), true));
+                user.write(MakerPacket.monsterCrystal(monsterCrystalId, itemId));
+                user.write(UserLocal.effect(Effect.itemMaker(MakerResult.SUCCESS)));
+                user.getField().broadcastPacket(UserRemote.effect(user, Effect.itemMaker(MakerResult.SUCCESS)));
             }
             case EQUIP_DISASSEMBLE -> {
                 final int itemId = inPacket.decodeInt(); // aRecipeSlot[0].pItem.p->nItemID
@@ -1108,58 +1060,56 @@ public final class UserHandler {
                     return;
                 }
                 final ItemMakeInfo itemMakeInfo = itemMakeInfoResult.get();
-                try (var locked = user.acquire()) {
-                    final InventoryManager im = locked.get().getInventoryManager();
-                    if (!im.canAddItems(itemMakeInfo.getRecipe())) {
-                        user.write(MakerPacket.emptySlot()); // You don't have enough room in your Inventory.
-                        return;
-                    }
-                    final Item item = im.getEquipInventory().getItem(slotPosition);
-                    if (item == null || item.getItemId() != itemId) {
-                        log.error("Could not resolve item ID : {} for disassembly at position : {}", itemId, slotPosition);
-                        user.write(MakerPacket.unknown());
-                        return;
-                    }
-                    final int totalCost = MakerConstants.getTotalCostToDisassemble(itemMakeInfo.getCost(), itemInfo.calcEquipItemQuality(item));
-                    if (!im.canAddMoney(-totalCost)) {
-                        user.write(MakerPacket.unknown());
-                        return;
-                    }
-                    final List<Item> rewardItems = new ArrayList<>();
-                    for (var tuple : itemMakeInfo.getRecipe()) {
-                        final int rewardItemId = tuple.getLeft();
-                        final int rewardItemCount = tuple.getRight() / 2; // TODO : probably incorrect
-                        if (rewardItemId / 10000 != 426 || rewardItemCount <= 0) {
-                            continue;
-                        }
-                        final Optional<ItemInfo> rewardItemInfoResult = ItemProvider.getItemInfo(rewardItemId);
-                        if (rewardItemInfoResult.isEmpty()) {
-                            log.error("Could not resolve item info for item ID : {}", itemId);
-                            user.write(MakerPacket.unknown());
-                            return;
-                        }
-                        rewardItems.add(rewardItemInfoResult.get().createItem(user.getNextItemSn(), rewardItemCount));
-                    }
-                    if (!im.addMoney(-totalCost)) {
-                        throw new IllegalStateException("Could not deduct total price from user");
-                    }
-                    final Optional<InventoryOperation> removeResult = im.removeItem(slotPosition, item);
-                    if (removeResult.isEmpty()) {
-                        throw new IllegalStateException("Failed to remove item from inventory");
-                    }
-                    for (Item rewardItem : rewardItems) {
-                        final Optional<List<InventoryOperation>> addResult = im.addItem(rewardItem);
-                        if (addResult.isEmpty()) {
-                            throw new IllegalStateException("Failed to add item to inventory");
-                        }
-                        user.write(WvsContext.inventoryOperation(addResult.get(), false));
-                    }
-                    user.write(WvsContext.inventoryOperation(removeResult.get(), false));
-                    user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
-                    user.write(MakerPacket.equipDisassemble(itemId, rewardItems, totalCost));
-                    user.write(UserLocal.effect(Effect.itemMaker(MakerResult.SUCCESS)));
-                    user.getField().broadcastPacket(UserRemote.effect(user, Effect.itemMaker(MakerResult.SUCCESS)));
+                final InventoryManager im = user.getInventoryManager();
+                if (!im.canAddItems(itemMakeInfo.getRecipe())) {
+                    user.write(MakerPacket.emptySlot()); // You don't have enough room in your Inventory.
+                    return;
                 }
+                final Item item = im.getEquipInventory().getItem(slotPosition);
+                if (item == null || item.getItemId() != itemId) {
+                    log.error("Could not resolve item ID : {} for disassembly at position : {}", itemId, slotPosition);
+                    user.write(MakerPacket.unknown());
+                    return;
+                }
+                final int totalCost = MakerConstants.getTotalCostToDisassemble(itemMakeInfo.getCost(), itemInfo.calcEquipItemQuality(item));
+                if (!im.canAddMoney(-totalCost)) {
+                    user.write(MakerPacket.unknown());
+                    return;
+                }
+                final List<Item> rewardItems = new ArrayList<>();
+                for (var tuple : itemMakeInfo.getRecipe()) {
+                    final int rewardItemId = tuple.getLeft();
+                    final int rewardItemCount = tuple.getRight() / 2; // TODO : probably incorrect
+                    if (rewardItemId / 10000 != 426 || rewardItemCount <= 0) {
+                        continue;
+                    }
+                    final Optional<ItemInfo> rewardItemInfoResult = ItemProvider.getItemInfo(rewardItemId);
+                    if (rewardItemInfoResult.isEmpty()) {
+                        log.error("Could not resolve item info for item ID : {}", itemId);
+                        user.write(MakerPacket.unknown());
+                        return;
+                    }
+                    rewardItems.add(rewardItemInfoResult.get().createItem(user.getNextItemSn(), rewardItemCount));
+                }
+                if (!im.addMoney(-totalCost)) {
+                    throw new IllegalStateException("Could not deduct total price from user");
+                }
+                final Optional<InventoryOperation> removeResult = im.removeItem(slotPosition, item);
+                if (removeResult.isEmpty()) {
+                    throw new IllegalStateException("Failed to remove item from inventory");
+                }
+                for (Item rewardItem : rewardItems) {
+                    final Optional<List<InventoryOperation>> addResult = im.addItem(rewardItem);
+                    if (addResult.isEmpty()) {
+                        throw new IllegalStateException("Failed to add item to inventory");
+                    }
+                    user.write(WvsContext.inventoryOperation(addResult.get(), false));
+                }
+                user.write(WvsContext.inventoryOperation(removeResult.get(), false));
+                user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
+                user.write(MakerPacket.equipDisassemble(itemId, rewardItems, totalCost));
+                user.write(UserLocal.effect(Effect.itemMaker(MakerResult.SUCCESS)));
+                user.getField().broadcastPacket(UserRemote.effect(user, Effect.itemMaker(MakerResult.SUCCESS)));
             }
             case null -> {
                 log.error("Unknown recipe class : {}", type);
@@ -1307,289 +1257,268 @@ public final class UserHandler {
             log.error("Unknown mini room action {}", action);
             return;
         }
-        try (var locked = user.acquire()) {
-            // TradingRoom Protocol
-            if (mrp.getValue() >= MiniRoomProtocol.TRP_PutItem.getValue() && mrp.getValue() <= MiniRoomProtocol.TRP_LimitFail.getValue()) {
-                if (!(user.getDialog() instanceof TradingRoom tradingRoom)) {
-                    log.error("Received trading room action {} outside a trading room", mrp);
-                    return;
-                }
-                tradingRoom.handlePacket(locked, mrp, inPacket);
+        // TradingRoom Protocol
+        if (mrp.getValue() >= MiniRoomProtocol.TRP_PutItem.getValue() && mrp.getValue() <= MiniRoomProtocol.TRP_LimitFail.getValue()) {
+            if (!(user.getDialog() instanceof TradingRoom tradingRoom)) {
+                log.error("Received trading room action {} outside a trading room", mrp);
                 return;
             }
-            // MiniGameRoom Protocol
-            if (mrp.getValue() >= MiniRoomProtocol.MGRP_TieRequest.getValue() && mrp.getValue() <= MiniRoomProtocol.MGP_MatchCard.getValue()) {
-                if (!(user.getDialog() instanceof MiniGameRoom miniGameRoom)) {
-                    log.error("Received mini game room action {} outside a mini game room", mrp);
-                    return;
-                }
-                miniGameRoom.handlePacket(locked, mrp, inPacket);
+            tradingRoom.handlePacket(user, mrp, inPacket);
+            return;
+        }
+        // MiniGameRoom Protocol
+        if (mrp.getValue() >= MiniRoomProtocol.MGRP_TieRequest.getValue() && mrp.getValue() <= MiniRoomProtocol.MGP_MatchCard.getValue()) {
+            if (!(user.getDialog() instanceof MiniGameRoom miniGameRoom)) {
+                log.error("Received mini game room action {} outside a mini game room", mrp);
                 return;
             }
-            // PersonalShop Protocol
-            if (mrp.getValue() >= MiniRoomProtocol.PSP_PutItem.getValue() && mrp.getValue() <= MiniRoomProtocol.PSP_DeleteBlackList.getValue()) {
-                if (!(user.getDialog() instanceof PersonalShop personalShop)) {
-                    log.error("Received personal shop action {} outside a personal shop", mrp);
-                    return;
-                }
-                personalShop.handlePacket(locked, mrp, inPacket);
+            miniGameRoom.handlePacket(user, mrp, inPacket);
+            return;
+        }
+        // PersonalShop Protocol
+        if (mrp.getValue() >= MiniRoomProtocol.PSP_PutItem.getValue() && mrp.getValue() <= MiniRoomProtocol.PSP_DeleteBlackList.getValue()) {
+            if (!(user.getDialog() instanceof PersonalShop personalShop)) {
+                log.error("Received personal shop action {} outside a personal shop", mrp);
                 return;
             }
-            // Common MiniRoom Protocol
-            final Field field = user.getField();
-            switch (mrp) {
-                case MRP_Create -> {
-                    final int type = inPacket.decodeByte();
-                    final MiniRoomType mrt = MiniRoomType.getByValue(type);
-                    if (user.getDialog() != null) {
-                        log.error("Tried to create mini room with another dialog open");
-                        user.write(BroadcastPacket.alert("This request has failed due to an unknown error."));
-                        return;
-                    }
-                    if (!field.getMiniRoomPool().canAddMiniRoom(mrt, user.getX(), user.getY())) {
-                        user.write(MiniRoomPacket.enterResult(EnterResultType.ExistMiniRoom)); // You can't establish a miniroom right here.
-                        return;
-                    }
-                    switch (mrt) {
-                        case OmokRoom, MemoryGameRoom -> {
-                            // CWvsContext::SendCreateMiniGameRequest
-                            final String title = inPacket.decodeString(); // sTitle
-                            final boolean isPrivate = inPacket.decodeBoolean();
-                            final String password = isPrivate ? inPacket.decodeString() : null;
-                            final int gameSpec = inPacket.decodeByte(); // nGameSpec
-                            // Check for required item
-                            if (mrt == MiniRoomType.OmokRoom) {
-                                final int requiredItem = ItemConstants.OMOK_SET_BASE + gameSpec;
-                                if (requiredItem < ItemConstants.OMOK_SET_BASE || requiredItem > ItemConstants.OMOK_SET_END ||
-                                        !user.getInventoryManager().hasItem(requiredItem, 1)) {
-                                    log.error("Tried to create omok game room without the required item");
-                                    return;
-                                }
-                            } else {
-                                if (!user.getInventoryManager().hasItem(ItemConstants.MATCH_CARDS, 1)) {
-                                    log.error("Tried to create memory game room without the required item");
-                                    return;
-                                }
-                            }
-                            // Create mini game room
-                            final MiniGameRoom miniGameRoom = mrt == MiniRoomType.OmokRoom ?
-                                    new OmokRoom(title, password, gameSpec) :
-                                    new MemoryGameRoom(title, password, gameSpec);
-                            try (var lockedRoom = miniGameRoom.acquire()) {
-                                miniGameRoom.addUser(0, user);
-                                field.getMiniRoomPool().addMiniRoom(miniGameRoom);
-                                user.setDialog(miniGameRoom);
-                                user.write(MiniRoomPacket.MiniGame.enterResult(miniGameRoom, user));
-                                miniGameRoom.updateBalloon();
-                            }
-                        }
-                        case TradingRoom -> {
-                            // CField::SendInviteTradingRoomMsg
-                            final TradingRoom tradingRoom = new TradingRoom();
-                            try (var lockedRoom = tradingRoom.acquire()) {
-                                tradingRoom.addUser(0, user);
-                                field.getMiniRoomPool().addMiniRoom(tradingRoom);
-                                user.setDialog(tradingRoom);
-                                user.write(MiniRoomPacket.enterResult(tradingRoom, user));
-                            }
-                        }
-                        case PersonalShop, EntrustedShop -> {
-                            // CWvsContext::SendOpenShopRequest
-                            final String title = inPacket.decodeString(); // sTitle
-                            inPacket.decodeByte(); // 0
-                            final int position = inPacket.decodeShort(); // nPOS
-                            final int itemId = inPacket.decodeInt(); // nItemID
-                            // Check field
-                            if (!field.getMapInfo().isShop()) {
-                                log.error("Tried to create player shop outside of the free market");
+            personalShop.handlePacket(user, mrp, inPacket);
+            return;
+        }
+        // Common MiniRoom Protocol
+        final Field field = user.getField();
+        switch (mrp) {
+            case MRP_Create -> {
+                final int type = inPacket.decodeByte();
+                final MiniRoomType mrt = MiniRoomType.getByValue(type);
+                if (user.getDialog() != null) {
+                    log.error("Tried to create mini room with another dialog open");
+                    user.write(BroadcastPacket.alert("This request has failed due to an unknown error."));
+                    return;
+                }
+                if (!field.getMiniRoomPool().canAddMiniRoom(mrt, user.getX(), user.getY())) {
+                    user.write(MiniRoomPacket.enterResult(EnterResultType.ExistMiniRoom)); // You can't establish a miniroom right here.
+                    return;
+                }
+                switch (mrt) {
+                    case OmokRoom, MemoryGameRoom -> {
+                        // CWvsContext::SendCreateMiniGameRequest
+                        final String title = inPacket.decodeString(); // sTitle
+                        final boolean isPrivate = inPacket.decodeBoolean();
+                        final String password = isPrivate ? inPacket.decodeString() : null;
+                        final int gameSpec = inPacket.decodeByte(); // nGameSpec
+                        // Check for required item
+                        if (mrt == MiniRoomType.OmokRoom) {
+                            final int requiredItem = ItemConstants.OMOK_SET_BASE + gameSpec;
+                            if (requiredItem < ItemConstants.OMOK_SET_BASE || requiredItem > ItemConstants.OMOK_SET_END ||
+                                    !user.getInventoryManager().hasItem(requiredItem, 1)) {
+                                log.error("Tried to create omok game room without the required item");
                                 return;
                             }
-                            // Check for required item
-                            if (mrt == MiniRoomType.PersonalShop) {
-                                if (itemId != ItemConstants.REGULAR_STORE_PERMIT || !user.getInventoryManager().hasItem(itemId, 1)) {
-                                    log.error("Tried to create personal shop without the required item");
-                                    return;
-                                }
-                                // Create personal shop
-                                final PersonalShop personalShop = new PersonalShop(title);
-                                try (var lockedRoom = personalShop.acquire()) {
-                                    personalShop.addUser(0, user);
-                                    field.getMiniRoomPool().addMiniRoom(personalShop);
-                                    user.setDialog(personalShop);
-                                    user.write(MiniRoomPacket.PlayerShop.enterResult(personalShop, user));
-                                }
-                            } else {
-                                if (itemId / 10000 != 503 || !user.getInventoryManager().hasItem(itemId, 1)) {
-                                    log.error("Tried to create entrusted shop without the required item");
-                                }
-                                // TODO: entrusted shop handling
+                        } else {
+                            if (!user.getInventoryManager().hasItem(ItemConstants.MATCH_CARDS, 1)) {
+                                log.error("Tried to create memory game room without the required item");
+                                return;
                             }
                         }
-                        case null -> {
-                            log.error("Tried to create unknown mini room type {}", type);
-                        }
-                        default -> {
-                            log.error("Tried to create unhandled mini room type {}", mrt);
-                        }
+                        // Create mini game room
+                        final MiniGameRoom miniGameRoom = mrt == MiniRoomType.OmokRoom ?
+                                new OmokRoom(title, password, gameSpec) :
+                                new MemoryGameRoom(title, password, gameSpec);
+                        miniGameRoom.addUser(0, user);
+                        field.getMiniRoomPool().addMiniRoom(miniGameRoom);
+                        user.setDialog(miniGameRoom);
+                        user.write(MiniRoomPacket.MiniGame.enterResult(miniGameRoom, user));
+                        miniGameRoom.updateBalloon();
                     }
-                }
-                case MRP_Invite -> {
-                    // CField::SendInviteTradingRoomMsg
-                    final int targetId = inPacket.decodeInt();
-                    if (!(user.getDialog() instanceof TradingRoom tradingRoom)) {
-                        log.error("Tried to invite user without a trading room");
-                        user.write(BroadcastPacket.alert("This request has failed due to an unknown error."));
-                        return;
+                    case TradingRoom -> {
+                        // CField::SendInviteTradingRoomMsg
+                        final TradingRoom tradingRoom = new TradingRoom();
+                        tradingRoom.addUser(0, user);
+                        field.getMiniRoomPool().addMiniRoom(tradingRoom);
+                        user.setDialog(tradingRoom);
+                        user.write(MiniRoomPacket.enterResult(tradingRoom, user));
                     }
-                    try (var lockedRoom = tradingRoom.acquire()) {
-                        final Optional<User> targetResult = field.getUserPool().getById(targetId);
-                        if (targetResult.isEmpty()) {
-                            user.write(MiniRoomPacket.inviteResult(MiniRoomInviteType.NoCharacter, null)); // Unable to find the character.
-                            tradingRoom.cancelTrade(locked, MiniRoomLeaveType.UserRequest);
+                    case PersonalShop, EntrustedShop -> {
+                        // CWvsContext::SendOpenShopRequest
+                        final String title = inPacket.decodeString(); // sTitle
+                        inPacket.decodeByte(); // 0
+                        final int position = inPacket.decodeShort(); // nPOS
+                        final int itemId = inPacket.decodeInt(); // nItemID
+                        // Check field
+                        if (!field.getMapInfo().isShop()) {
+                            log.error("Tried to create player shop outside of the free market");
                             return;
                         }
-                        try (var lockedTarget = targetResult.get().acquire()) {
-                            final User target = lockedTarget.get();
-                            if (target.getDialog() != null) {
-                                user.write(MiniRoomPacket.inviteResult(MiniRoomInviteType.CannotInvite, target.getCharacterName())); // '%s' is doing something else right now.
-                                tradingRoom.cancelTrade(locked, MiniRoomLeaveType.UserRequest);
+                        // Check for required item
+                        if (mrt == MiniRoomType.PersonalShop) {
+                            if (itemId != ItemConstants.REGULAR_STORE_PERMIT || !user.getInventoryManager().hasItem(itemId, 1)) {
+                                log.error("Tried to create personal shop without the required item");
                                 return;
                             }
-                            target.write(MiniRoomPacket.inviteStatic(MiniRoomType.TradingRoom, user.getCharacterName(), tradingRoom.getId()));
-                        }
-                    }
-                }
-                case MRP_InviteResult -> {
-                    // CMiniRoomBaseDlg::SendInviteResult
-                    final int miniRoomId = inPacket.decodeInt(); // dwSN
-                    final int type = inPacket.decodeByte(); // nErrCode
-                    final MiniRoomInviteType resultType = MiniRoomInviteType.getByValue(type);
-                    if (resultType == null) {
-                        log.error("Unknown invite result type {}", type);
-                        return;
-                    }
-                    // Resolve trading room
-                    final Optional<MiniRoom> miniRoomResult = field.getMiniRoomPool().getById(miniRoomId);
-                    if (miniRoomResult.isEmpty() || !(miniRoomResult.get() instanceof TradingRoom tradingRoom)) {
-                        return;
-                    }
-                    // Cancel trade
-                    try (var lockedRoom = tradingRoom.acquire()) {
-                        try (var lockedOwner = tradingRoom.getUser(0).acquire()) {
-                            lockedOwner.get().write(MiniRoomPacket.inviteResult(resultType, user.getCharacterName()));
-                            tradingRoom.cancelTrade(lockedOwner, MiniRoomLeaveType.UserRequest);
-                        }
-                    }
-                }
-                case MRP_Enter -> {
-                    // CMiniRoomBaseDlg::SendInviteResult
-                    // CUserLocal::HandleLButtonDblClk
-                    final int miniRoomId = inPacket.decodeInt(); // dwSN
-                    final boolean isPrivate = inPacket.decodeBoolean();
-                    final String password = isPrivate ? inPacket.decodeString() : null;
-                    inPacket.decodeByte(); // 0
-                    if (user.getDialog() != null) {
-                        log.error("Tried to enter mini room with another dialog open");
-                        user.write(BroadcastPacket.alert("This request has failed due to an unknown error."));
-                        return;
-                    }
-                    // Resolve mini room
-                    final Optional<MiniRoom> miniRoomResult = field.getMiniRoomPool().getById(miniRoomId);
-                    if (miniRoomResult.isEmpty()) {
-                        user.write(MiniRoomPacket.enterResult(EnterResultType.NoRoom)); // The room is already closed.
-                        return;
-                    }
-                    try (var lockedRoom = miniRoomResult.get().acquire()) {
-                        final MiniRoom miniRoom = lockedRoom.get();
-                        // Check password
-                        if (!miniRoom.checkPassword(password)) {
-                            user.write(MiniRoomPacket.enterResult(EnterResultType.InvalidPassword)); // The password is incorrect.
-                            return;
-                        }
-                        // Handle for each mini room type
-                        if (miniRoom instanceof MiniGameRoom miniGameRoom) {
-                            if (miniGameRoom.getUser(1) != null) {
-                                user.write(MiniRoomPacket.enterResult(EnterResultType.Full)); // You can't enter the room due to full capacity.
-                                return;
-                            }
-                            miniGameRoom.broadcastPacket(MiniRoomPacket.MiniGame.enter(1, user, miniGameRoom.getType()));
-                            miniGameRoom.addUser(1, user);
-                            miniGameRoom.updateBalloon();
-                            user.setDialog(miniGameRoom);
-                            user.write(MiniRoomPacket.MiniGame.enterResult(miniGameRoom, user));
-                        } else if (miniRoom instanceof TradingRoom tradingRoom) {
-                            if (tradingRoom.getUser(1) != null) {
-                                user.write(MiniRoomPacket.enterResult(EnterResultType.Full)); // You can't enter the room due to full capacity.
-                                return;
-                            }
-                            tradingRoom.broadcastPacket(MiniRoomPacket.enterBase(1, user));
-                            tradingRoom.addUser(1, user);
-                            user.setDialog(tradingRoom);
-                            user.write(MiniRoomPacket.enterResult(tradingRoom, user));
-                        } else if (miniRoom instanceof PersonalShop personalShop) {
-                            final int userIndex = personalShop.getOpenUserIndex();
-                            if (!personalShop.isOpen() || userIndex < 0) {
-                                user.write(MiniRoomPacket.enterResult(EnterResultType.Full)); // You can't enter the room due to full capacity.
-                                return;
-                            }
-                            personalShop.broadcastPacket(MiniRoomPacket.enterBase(userIndex, user));
-                            personalShop.addUser(userIndex, user);
-                            personalShop.updateBalloon();
+                            // Create personal shop
+                            final PersonalShop personalShop = new PersonalShop(title);
+                            personalShop.addUser(0, user);
+                            field.getMiniRoomPool().addMiniRoom(personalShop);
                             user.setDialog(personalShop);
                             user.write(MiniRoomPacket.PlayerShop.enterResult(personalShop, user));
                         } else {
-                            log.error("Tried to enter mini room with unhandled type : {}", miniRoom.getType());
-                            user.write(BroadcastPacket.alert("This request has failed due to an unknown error."));
+                            if (itemId / 10000 != 503 || !user.getInventoryManager().hasItem(itemId, 1)) {
+                                log.error("Tried to create entrusted shop without the required item");
+                            }
+                            // TODO: entrusted shop handling
                         }
                     }
+                    case null -> {
+                        log.error("Tried to create unknown mini room type {}", type);
+                    }
+                    default -> {
+                        log.error("Tried to create unhandled mini room type {}", mrt);
+                    }
                 }
-                case MRP_Chat -> {
-                    // CMiniRoomBaseDlg::CheckAndSendChat
-                    inPacket.decodeInt(); // update_time
-                    final String message = inPacket.decodeString(); // strChatMsg
-                    if (!(user.getDialog() instanceof MiniRoom miniRoom)) {
-                        log.error("Received {} without a mini room", mrp);
+            }
+            case MRP_Invite -> {
+                // CField::SendInviteTradingRoomMsg
+                final int targetId = inPacket.decodeInt();
+                if (!(user.getDialog() instanceof TradingRoom tradingRoom)) {
+                    log.error("Tried to invite user without a trading room");
+                    user.write(BroadcastPacket.alert("This request has failed due to an unknown error."));
+                    return;
+                }
+                final Optional<User> targetResult = field.getUserPool().getById(targetId);
+                if (targetResult.isEmpty()) {
+                    user.write(MiniRoomPacket.inviteResult(MiniRoomInviteType.NoCharacter, null)); // Unable to find the character.
+                    tradingRoom.cancelTrade(user, MiniRoomLeaveType.UserRequest);
+                    return;
+                }
+                final User target = targetResult.get();
+                if (target.getDialog() != null) {
+                    user.write(MiniRoomPacket.inviteResult(MiniRoomInviteType.CannotInvite, target.getCharacterName())); // '%s' is doing something else right now.
+                    tradingRoom.cancelTrade(user, MiniRoomLeaveType.UserRequest);
+                    return;
+                }
+                target.write(MiniRoomPacket.inviteStatic(MiniRoomType.TradingRoom, user.getCharacterName(), tradingRoom.getId()));
+            }
+            case MRP_InviteResult -> {
+                // CMiniRoomBaseDlg::SendInviteResult
+                final int miniRoomId = inPacket.decodeInt(); // dwSN
+                final int type = inPacket.decodeByte(); // nErrCode
+                final MiniRoomInviteType resultType = MiniRoomInviteType.getByValue(type);
+                if (resultType == null) {
+                    log.error("Unknown invite result type {}", type);
+                    return;
+                }
+                // Resolve trading room
+                final Optional<MiniRoom> miniRoomResult = field.getMiniRoomPool().getById(miniRoomId);
+                if (miniRoomResult.isEmpty() || !(miniRoomResult.get() instanceof TradingRoom tradingRoom)) {
+                    return;
+                }
+                // Cancel trade
+                final User owner = tradingRoom.getUser(0);
+                owner.write(MiniRoomPacket.inviteResult(resultType, user.getCharacterName()));
+                tradingRoom.cancelTrade(owner, MiniRoomLeaveType.UserRequest);
+            }
+            case MRP_Enter -> {
+                // CMiniRoomBaseDlg::SendInviteResult
+                // CUserLocal::HandleLButtonDblClk
+                final int miniRoomId = inPacket.decodeInt(); // dwSN
+                final boolean isPrivate = inPacket.decodeBoolean();
+                final String password = isPrivate ? inPacket.decodeString() : null;
+                inPacket.decodeByte(); // 0
+                if (user.getDialog() != null) {
+                    log.error("Tried to enter mini room with another dialog open");
+                    user.write(BroadcastPacket.alert("This request has failed due to an unknown error."));
+                    return;
+                }
+                // Resolve mini room
+                final Optional<MiniRoom> miniRoomResult = field.getMiniRoomPool().getById(miniRoomId);
+                if (miniRoomResult.isEmpty()) {
+                    user.write(MiniRoomPacket.enterResult(EnterResultType.NoRoom)); // The room is already closed.
+                    return;
+                }
+                final MiniRoom miniRoom = miniRoomResult.get();
+                // Check password
+                if (!miniRoom.checkPassword(password)) {
+                    user.write(MiniRoomPacket.enterResult(EnterResultType.InvalidPassword)); // The password is incorrect.
+                    return;
+                }
+                // Handle for each mini room type
+                if (miniRoom instanceof MiniGameRoom miniGameRoom) {
+                    if (miniGameRoom.getUser(1) != null) {
+                        user.write(MiniRoomPacket.enterResult(EnterResultType.Full)); // You can't enter the room due to full capacity.
                         return;
                     }
-                    try (var lockedRoom = miniRoom.acquire()) {
-                        final int userIndex = miniRoom.getUserIndex(user);
-                        if (userIndex < 0) {
-                            log.error("Received {} with user index", userIndex);
-                            return;
-                        }
-                        miniRoom.broadcastPacket(MiniRoomPacket.chat(userIndex, user.getCharacterName(), message));
-                    }
-                }
-                case MRP_Leave -> {
-                    if (!(user.getDialog() instanceof MiniRoom miniRoom)) {
-                        log.error("Received {} without a mini room", mrp);
+                    miniGameRoom.broadcastPacket(MiniRoomPacket.MiniGame.enter(1, user, miniGameRoom.getType()));
+                    miniGameRoom.addUser(1, user);
+                    miniGameRoom.updateBalloon();
+                    user.setDialog(miniGameRoom);
+                    user.write(MiniRoomPacket.MiniGame.enterResult(miniGameRoom, user));
+                } else if (miniRoom instanceof TradingRoom tradingRoom) {
+                    if (tradingRoom.getUser(1) != null) {
+                        user.write(MiniRoomPacket.enterResult(EnterResultType.Full)); // You can't enter the room due to full capacity.
                         return;
                     }
-                    try (var lockedRoom = miniRoom.acquire()) {
-                        final int userIndex = miniRoom.getUserIndex(user);
-                        if (userIndex < 0) {
-                            log.error("Received {} with user index", userIndex);
-                            return;
-                        }
-                        miniRoom.leaveUnsafe(user);
-                    }
-                }
-                case MRP_Balloon -> {
-                    final boolean open = inPacket.decodeBoolean();
-                    if (!(user.getDialog() instanceof MiniRoom miniRoom)) {
-                        log.error("Received {} without a mini room", mrp);
+                    tradingRoom.broadcastPacket(MiniRoomPacket.enterBase(1, user));
+                    tradingRoom.addUser(1, user);
+                    user.setDialog(tradingRoom);
+                    user.write(MiniRoomPacket.enterResult(tradingRoom, user));
+                } else if (miniRoom instanceof PersonalShop personalShop) {
+                    final int userIndex = personalShop.getOpenUserIndex();
+                    if (!personalShop.isOpen() || userIndex < 0) {
+                        user.write(MiniRoomPacket.enterResult(EnterResultType.Full)); // You can't enter the room due to full capacity.
                         return;
                     }
-                    if (miniRoom instanceof PersonalShop personalShop) {
-                        personalShop.setOpen(open);
-                        personalShop.updateBalloon();
-                    } else {
-                        log.error("Received {} for unhandled mini room type {}", mrp, miniRoom.getType());
-                    }
+                    personalShop.broadcastPacket(MiniRoomPacket.enterBase(userIndex, user));
+                    personalShop.addUser(userIndex, user);
+                    personalShop.updateBalloon();
+                    user.setDialog(personalShop);
+                    user.write(MiniRoomPacket.PlayerShop.enterResult(personalShop, user));
+                } else {
+                    log.error("Tried to enter mini room with unhandled type : {}", miniRoom.getType());
+                    user.write(BroadcastPacket.alert("This request has failed due to an unknown error."));
                 }
-                default -> {
-                    log.error("Unhandled mini room action {}", mrp);
+            }
+            case MRP_Chat -> {
+                // CMiniRoomBaseDlg::CheckAndSendChat
+                inPacket.decodeInt(); // update_time
+                final String message = inPacket.decodeString(); // strChatMsg
+                if (!(user.getDialog() instanceof MiniRoom miniRoom)) {
+                    log.error("Received {} without a mini room", mrp);
+                    return;
                 }
+                final int userIndex = miniRoom.getUserIndex(user);
+                if (userIndex < 0) {
+                    log.error("Received {} with user index", userIndex);
+                    return;
+                }
+                miniRoom.broadcastPacket(MiniRoomPacket.chat(userIndex, user.getCharacterName(), message));
+            }
+            case MRP_Leave -> {
+                if (!(user.getDialog() instanceof MiniRoom miniRoom)) {
+                    log.error("Received {} without a mini room", mrp);
+                    return;
+                }
+                final int userIndex = miniRoom.getUserIndex(user);
+                if (userIndex < 0) {
+                    log.error("Received {} with user index", userIndex);
+                    return;
+                }
+                miniRoom.leave(user);
+            }
+            case MRP_Balloon -> {
+                final boolean open = inPacket.decodeBoolean();
+                if (!(user.getDialog() instanceof MiniRoom miniRoom)) {
+                    log.error("Received {} without a mini room", mrp);
+                    return;
+                }
+                if (miniRoom instanceof PersonalShop personalShop) {
+                    personalShop.setOpen(open);
+                    personalShop.updateBalloon();
+                } else {
+                    log.error("Received {} for unhandled mini room type {}", mrp, miniRoom.getType());
+                }
+            }
+            default -> {
+                log.error("Unhandled mini room action {}", mrp);
             }
         }
     }
@@ -1635,55 +1564,54 @@ public final class UserHandler {
                 final Optional<Tuple<Commodity, List<Commodity>>> packageResult = CashShop.getCashPackage(gift.getCommodityId());
                 final int commodityCount = packageResult.map(tuple -> tuple.getRight().size()).orElse(1);
                 // Receive gift
-                try (var lockedAccount = user.getAccount().acquire()) {
-                    final Locker locker = lockedAccount.get().getLocker();
-                    if (locker.getRemaining() < commodityCount) {
-                        user.write(BroadcastPacket.alert("Could not receive gift as the locker is full."));
-                        return;
-                    }
-                    // Create CashItemInfo(s)
-                    final List<CashItemInfo> cashItemInfos = new ArrayList<>();
-                    if (packageResult.isPresent()) {
-                        // Cash package
-                        for (Commodity commodity : packageResult.get().getRight()) {
-                            final Optional<CashItemInfo> cashItemInfoResult = commodity.createCashItemInfo(gift.getGiftSn(), user.getAccountId(), user.getCharacterId(), gift.getSenderName());
-                            if (cashItemInfoResult.isEmpty()) {
-                                log.error("Failed to create cash item info for gift commodity ID : {}", commodity.getCommodityId());
-                                user.write(CashShopPacket.fail(CashItemResultType.Gift_Failed, CashItemFailReason.Unknown)); // Due to an unknown error, the request for Cash Shop has failed.
-                                return;
-                            }
-                            cashItemInfos.add(cashItemInfoResult.get());
-                        }
-                    } else {
-                        // Normal gift
-                        final Optional<CashItemInfo> cashItemInfoResult = commodityResult.get().createCashItemInfo(gift.getGiftSn(), user.getAccountId(), user.getCharacterId(), gift.getSenderName());
+                final Locker locker = user.getAccount().getLocker();
+                if (locker.getRemaining() < commodityCount) {
+                    user.write(BroadcastPacket.alert("Could not receive gift as the locker is full."));
+                    return;
+                }
+                // Create CashItemInfo(s)
+                final List<CashItemInfo> cashItemInfos = new ArrayList<>();
+                if (packageResult.isPresent()) {
+                    // Cash package
+                    for (Commodity commodity : packageResult.get().getRight()) {
+                        final Optional<CashItemInfo> cashItemInfoResult = commodity.createCashItemInfo(gift.getGiftSn(), user.getAccountId(), user.getCharacterId(), gift.getSenderName());
                         if (cashItemInfoResult.isEmpty()) {
-                            log.error("Failed to create cash item info for gift commodity ID : {}", gift.getCommodityId());
+                            log.error("Failed to create cash item info for gift commodity ID : {}", commodity.getCommodityId());
                             user.write(CashShopPacket.fail(CashItemResultType.Gift_Failed, CashItemFailReason.Unknown)); // Due to an unknown error, the request for Cash Shop has failed.
                             return;
                         }
-                        final CashItemInfo cashItemInfo = cashItemInfoResult.get();
-                        // Create RingData if pairItemSn was set
-                        if (gift.getPairItemSn() != 0) {
-                            final RingData ringData = new RingData();
-                            ringData.setPairCharacterId(gift.getSenderId());
-                            ringData.setPairCharacterName(gift.getSenderName());
-                            ringData.setPairItemSn(gift.getPairItemSn());
-                            cashItemInfo.getItem().setRingData(ringData);
-                        }
-                        cashItemInfos.add(cashItemInfo);
+                        cashItemInfos.add(cashItemInfoResult.get());
                     }
-                    // Delete gift from DB and add to locker
-                    if (!DatabaseManager.giftAccessor().deleteGift(gift)) {
-                        log.error("Failed to delete gift with sn : {}", gift.getGiftSn());
+                } else {
+                    // Normal gift
+                    final Optional<CashItemInfo> cashItemInfoResult = commodityResult.get().createCashItemInfo(gift.getGiftSn(), user.getAccountId(), user.getCharacterId(), gift.getSenderName());
+                    if (cashItemInfoResult.isEmpty()) {
+                        log.error("Failed to create cash item info for gift commodity ID : {}", gift.getCommodityId());
                         user.write(CashShopPacket.fail(CashItemResultType.Gift_Failed, CashItemFailReason.Unknown)); // Due to an unknown error, the request for Cash Shop has failed.
                         return;
                     }
-                    for (CashItemInfo cashItemInfo : cashItemInfos) {
-                        locker.addCashItem(cashItemInfo);
+                    final CashItemInfo cashItemInfo = cashItemInfoResult.get();
+                    // Create RingData if pairItemSn was set
+                    if (gift.getPairItemSn() != 0) {
+                        final RingData ringData = new RingData();
+                        ringData.setPairCharacterId(gift.getSenderId());
+                        ringData.setPairCharacterName(gift.getSenderName());
+                        ringData.setPairItemSn(gift.getPairItemSn());
+                        cashItemInfo.getItem().setRingData(ringData);
                     }
-                    user.write(CashShopPacket.loadLockerDone(lockedAccount.get()));
+                    cashItemInfos.add(cashItemInfo);
                 }
+                // Delete gift from DB and add to locker
+                if (!DatabaseManager.giftAccessor().deleteGift(gift)) {
+                    log.error("Failed to delete gift with sn : {}", gift.getGiftSn());
+                    user.write(CashShopPacket.fail(CashItemResultType.Gift_Failed, CashItemFailReason.Unknown)); // Due to an unknown error, the request for Cash Shop has failed.
+                    return;
+                }
+                for (CashItemInfo cashItemInfo : cashItemInfos) {
+                    locker.addCashItem(cashItemInfo);
+                }
+                user.write(CashShopPacket.loadLockerDone(user.getAccount()));
+
                 // Resolve receiver
                 final Optional<CharacterInfo> receiverIdResult = DatabaseManager.characterAccessor().getCharacterInfoByName(receiverName);
                 if (receiverIdResult.isEmpty()) {
@@ -1729,10 +1657,8 @@ public final class UserHandler {
                         final int marriageId = inPacket.decodeInt(); // atoi(strMarriageNo)
                         log.error("Unhandled Marriage invitation memo for marriage ID : {}", marriageId);
                     } else if (memoType == MemoType.INCPOP) {
-                        try (var locked = user.acquire()) {
-                            locked.get().addPop(1);
-                            user.write(MessagePacket.incPop(1));
-                        }
+                        user.addPop(1);
+                        user.write(MessagePacket.incPop(1));
                     }
                 }
             }
@@ -1764,20 +1690,18 @@ public final class UserHandler {
         }
         final TownPortal townPortal = townPortalResult.get();
         final int townPortalId = 0x80 | townPortal.getOwner().getTownPortalIndex(); // CUserLocal::Init
-        try (var locked = user.acquire()) {
-            if (townPortal.getTownField() == user.getField()) {
-                user.warp(townPortal.getField(), townPortal.getX(), townPortal.getY(), townPortalId, false, false);
+        if (townPortal.getTownField() == user.getField()) {
+            user.warp(townPortal.getField(), townPortal.getX(), townPortal.getY(), townPortalId, false, false);
+        } else {
+            final int x, y;
+            final Optional<PortalInfo> portalPointResult = townPortal.getTownPortalPoint();
+            if (portalPointResult.isPresent()) {
+                x = portalPointResult.get().getX();
+                y = portalPointResult.get().getY();
             } else {
-                final int x, y;
-                final Optional<PortalInfo> portalPointResult = townPortal.getTownPortalPoint();
-                if (portalPointResult.isPresent()) {
-                    x = portalPointResult.get().getX();
-                    y = portalPointResult.get().getY();
-                } else {
-                    x = y = 0;
-                }
-                user.warp(townPortal.getTownField(), x, y, townPortalId, false, false);
+                x = y = 0;
             }
+            user.warp(townPortal.getTownField(), x, y, townPortalId, false, false);
         }
     }
 
@@ -1795,43 +1719,41 @@ public final class UserHandler {
     public static void handleFuncKeyMappedModified(User user, InPacket inPacket) {
         final int type = inPacket.decodeInt();
         final FuncKeyMappedType funcKeyMappedType = FuncKeyMappedType.getByValue(type);
-        try (var locked = user.acquire()) {
-            final ConfigManager cm = locked.get().getConfigManager();
-            switch (funcKeyMappedType) {
-                case KeyModified -> {
-                    final int size = inPacket.decodeInt(); // *(anChangedIdx.a - 1)
-                    final Map<Integer, FuncKeyMapped> updates = new HashMap<>();
-                    for (int i = 0; i < size; i++) {
-                        final int index = inPacket.decodeInt();
+        final ConfigManager cm = user.getConfigManager();
+        switch (funcKeyMappedType) {
+            case KeyModified -> {
+                final int size = inPacket.decodeInt(); // *(anChangedIdx.a - 1)
+                final Map<Integer, FuncKeyMapped> updates = new HashMap<>();
+                for (int i = 0; i < size; i++) {
+                    final int index = inPacket.decodeInt();
 
-                        // FUNCKEY_MAPPED::Encode
-                        final int funcKeyValue = inPacket.decodeByte(); // nType
-                        final int funcKeyId = inPacket.decodeInt(); // nID
-                        // ~FUNCKEY_MAPPED::Encode
+                    // FUNCKEY_MAPPED::Encode
+                    final int funcKeyValue = inPacket.decodeByte(); // nType
+                    final int funcKeyId = inPacket.decodeInt(); // nID
+                    // ~FUNCKEY_MAPPED::Encode
 
-                        final FuncKeyType funcKeyType = FuncKeyType.getByValue(funcKeyValue);
-                        if (funcKeyType == null) {
-                            log.error("Received unknown func key type {}", funcKeyValue);
-                            return;
-                        }
-                        updates.put(index, FuncKeyMapped.of(funcKeyType, funcKeyId));
+                    final FuncKeyType funcKeyType = FuncKeyType.getByValue(funcKeyValue);
+                    if (funcKeyType == null) {
+                        log.error("Received unknown func key type {}", funcKeyValue);
+                        return;
                     }
-                    cm.updateFuncKeyMap(updates);
+                    updates.put(index, FuncKeyMapped.of(funcKeyType, funcKeyId));
                 }
-                case PetConsumeItemModified -> {
-                    final int itemId = inPacket.decodeInt(); // nPetConsumeItemID
-                    cm.setPetConsumeItem(itemId);
-                }
-                case PetConsumeMPItemModified -> {
-                    final int itemId = inPacket.decodeInt(); // nPetConsumeMPItemID
-                    cm.setPetConsumeMpItem(itemId);
-                }
-                case null -> {
-                    log.error("Received unknown type {} for FuncKeyMappedModified", type);
-                }
-                default -> {
-                    log.error("Unhandled func key mapped type : {}", funcKeyMappedType);
-                }
+                cm.updateFuncKeyMap(updates);
+            }
+            case PetConsumeItemModified -> {
+                final int itemId = inPacket.decodeInt(); // nPetConsumeItemID
+                cm.setPetConsumeItem(itemId);
+            }
+            case PetConsumeMPItemModified -> {
+                final int itemId = inPacket.decodeInt(); // nPetConsumeMPItemID
+                cm.setPetConsumeMpItem(itemId);
+            }
+            case null -> {
+                log.error("Received unknown type {} for FuncKeyMappedModified", type);
+            }
+            default -> {
+                log.error("Unhandled func key mapped type : {}", funcKeyMappedType);
             }
         }
     }
@@ -1867,19 +1789,15 @@ public final class UserHandler {
         for (int i = 0; i < quickslotKeyMap.length; i++) {
             quickslotKeyMap[i] = inPacket.decodeInt();
         }
-        try (var locked = user.acquire()) {
-            final ConfigManager cm = locked.get().getConfigManager();
-            cm.updateQuickslotKeyMap(quickslotKeyMap);
-        }
+        final ConfigManager cm = user.getConfigManager();
+        cm.updateQuickslotKeyMap(quickslotKeyMap);
     }
 
     @Handler(InHeader.PassiveskillInfoUpdate)
     public static void handlePassiveSkillInfoUpdate(User user, InPacket inPacket) {
         inPacket.decodeInt(); // update_time
-        try (var locked = user.acquire()) {
-            user.updatePassiveSkillData();
-            user.validateStat();
-        }
+        user.updatePassiveSkillData();
+        user.validateStat();
     }
 
     @Handler(InHeader.UpdateScreenSetting)

--- a/src/main/java/kinoko/handler/user/item/CashItemHandler.java
+++ b/src/main/java/kinoko/handler/user/item/CashItemHandler.java
@@ -58,598 +58,589 @@ public final class CashItemHandler extends ItemHandler {
         }
         final ItemInfo itemInfo = itemInfoResult.get();
 
-        try (var locked = user.acquire()) {
-            // Check item
-            final InventoryManager im = locked.get().getInventoryManager();
-            final Item item = im.getInventoryByType(InventoryType.CASH).getItem(position);
-            if (item == null || item.getItemId() != itemId) {
-                log.error("Tried to use an item in position {} as item ID : {}", position, itemId);
-                user.dispose();
-                return;
-            }
+        // Check item
+        final InventoryManager im = user.getInventoryManager();
+        final Item item = im.getInventoryByType(InventoryType.CASH).getItem(position);
+        if (item == null || item.getItemId() != itemId) {
+            log.error("Tried to use an item in position {} as item ID : {}", position, itemId);
+            user.dispose();
+            return;
+        }
 
-            final CashItemType cashItemType = CashItemType.getByItemId(item.getItemId());
-            switch (cashItemType) {
-                case SPEAKERCHANNEL -> {
-                    final String message = formatSpeakerMessage(user, inPacket.decodeString());
-                    // Check level
-                    if (user.getLevel() < 10) {
-                        user.write(WvsContext.avatarMegaphoneResLevelLimit()); // This megaphone is only available for characters that are over Level 10.
-                        return;
-                    }
-                    // Remove item
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        log.error("Could not remove speaker channel item from inventory");
-                        user.dispose();
-                        return;
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), true));
-                    // Channel broadcast
-                    user.getConnectedServer().submitChannelPacketBroadcast(BroadcastPacket.speakerChannel(message));
+        final CashItemType cashItemType = CashItemType.getByItemId(item.getItemId());
+        switch (cashItemType) {
+            case SPEAKERCHANNEL -> {
+                final String message = formatSpeakerMessage(user, inPacket.decodeString());
+                // Check level
+                if (user.getLevel() < 10) {
+                    user.write(WvsContext.avatarMegaphoneResLevelLimit()); // This megaphone is only available for characters that are over Level 10.
+                    return;
                 }
-                case SPEAKERWORLD, SKULLSPEAKER -> {
-                    final String message = formatSpeakerMessage(user, inPacket.decodeString());
-                    final boolean whisperIcon = inPacket.decodeBoolean();
-                    final OutPacket outPacket = cashItemType == CashItemType.SPEAKERWORLD ?
-                            BroadcastPacket.speakerWorld(message, user.getChannelId(), whisperIcon) :
-                            BroadcastPacket.skullSpeaker(message, user.getChannelId(), whisperIcon);
-                    handleWorldSpeaker(user, position, item, false, outPacket);
-                }
-                case ITEMSPEAKER -> {
-                    final String message = formatSpeakerMessage(user, inPacket.decodeString());
-                    final boolean whisperIcon = inPacket.decodeBoolean();
-                    final Item targetItem;
-                    if (inPacket.decodeBoolean()) {
-                        final int targetType = inPacket.decodeInt(); // nTargetTI
-                        final int targetPosition = inPacket.decodeInt(); // nTargetPOS
-                        final InventoryType inventoryType = InventoryType.getByPosition(InventoryType.getByValue(targetType), targetPosition);
-                        if (inventoryType == null) {
-                            log.error("Received unknown target inventory type {} for item speaker", targetType);
-                            user.dispose();
-                            return;
-                        }
-                        targetItem = im.getInventoryByType(inventoryType).getItem(targetPosition);
-                    } else {
-                        targetItem = null;
-                    }
-                    handleWorldSpeaker(user, position, item, false, BroadcastPacket.itemSpeaker(message, targetItem, user.getChannelId(), whisperIcon));
-                }
-                case ARTSPEAKERWORLD -> {
-                    final List<String> messages = new ArrayList<>();
-                    final int size = inPacket.decodeByte();
-                    for (int i = 0; i < size; i++) {
-                        messages.add(formatSpeakerMessage(user, inPacket.decodeString()));
-                    }
-                    final boolean whisperIcon = inPacket.decodeBoolean();
-                    handleWorldSpeaker(user, position, item, false, BroadcastPacket.artSpeakerWorld(messages, user.getChannelId(), whisperIcon));
-                }
-                case AVATARMEGAPHONE -> {
-                    final String s1 = inPacket.decodeString();
-                    final String s2 = inPacket.decodeString();
-                    final String s3 = inPacket.decodeString();
-                    final String s4 = inPacket.decodeString();
-                    final boolean whisperIcon = inPacket.decodeBoolean();
-                    handleWorldSpeaker(user, position, item, true, WvsContext.avatarMegaphoneUpdateMessage(user, itemId, s1, s2, s3, s4, whisperIcon));
-                }
-                case MAPLETV, MAPLESOLETV, MAPLELOVETV, MEGATV, MEGASOLETV, MEGALOVETV -> {
-                    final boolean isMega = cashItemType == CashItemType.MEGATV || cashItemType == CashItemType.MEGASOLETV || cashItemType == CashItemType.MEGALOVETV;
-                    final int type = switch (cashItemType) {
-                        case MAPLESOLETV, MEGASOLETV -> 1;
-                        case MAPLELOVETV, MEGALOVETV -> 2;
-                        default -> 0;
-                    };
-                    final int flag = type == 0 ? inPacket.decodeByte() : (type == 1 ? 1 : 3);
-                    final boolean whisperIcon = isMega && inPacket.decodeBoolean();
-                    String receiverName = null;
-                    AvatarLook receiver = null;
-                    if ((flag & 2) != 0) {
-                        receiverName = inPacket.decodeString();
-                        final Optional<User> receiverResult = user.getField().getUserPool().getByCharacterName(receiverName);
-                        if (receiverResult.isEmpty()) {
-                            user.write(WvsContext.mapleTvUseRes("Unable to find the character."));
-                            return;
-                        }
-                        try (var lockedReceiver = receiverResult.get().acquire()) {
-                            receiver = lockedReceiver.get().getCharacterData().getAvatarLook();
-                        }
-                    }
-                    final String s1 = inPacket.decodeString();
-                    final String s2 = inPacket.decodeString();
-                    final String s3 = inPacket.decodeString();
-                    final String s4 = inPacket.decodeString();
-                    final String s5 = inPacket.decodeString();
-                    // Check maple tv queue
-                    final Instant expireTime;
-                    final int duration = type == 0 ? 15 : (type == 1 ? 30 : 60);
-                    if (user.getField().getMapleTvQueue().isEmpty()) {
-                        expireTime = Instant.now().plus(duration, ChronoUnit.SECONDS);
-                    } else {
-                        final Instant lastExpire = user.getField().getMapleTvQueue().getLast().getExpireTime();
-                        if (lastExpire.isAfter(Instant.now().plus(60, ChronoUnit.SECONDS))) {
-                            user.write(WvsContext.mapleTvUseRes("The waiting line is longer than a minute. Please try using it at a later time."));
-                            return;
-                        }
-                        expireTime = lastExpire.plus(duration, ChronoUnit.SECONDS);
-                    }
-                    // Remove item
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        log.error("Could not remove maple tv item from inventory");
-                        user.dispose();
-                        return;
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), true));
-                    // Show message
-                    final MapleTvMessage message = new MapleTvMessage(
-                            flag,
-                            type,
-                            user.getCharacterData().getAvatarLook(),
-                            user.getCharacterName(),
-                            receiver,
-                            receiverName,
-                            s1,
-                            s2,
-                            s3,
-                            s4,
-                            s5,
-                            expireTime
-                    );
-                    final int totalWaitTime = (int) Math.max(expireTime.getEpochSecond() - Instant.now().getEpochSecond(), 0);
-                    if (user.getField().getMapleTvQueue().isEmpty()) {
-                        user.getField().broadcastPacket(MapleTvPacket.updateMessage(message, totalWaitTime));
-                    }
-                    user.getField().getMapleTvQueue().addLast(message);
-                    if (isMega) {
-                        user.getConnectedServer().submitWorldSpeakerRequest(user.getCharacterId(), false, BroadcastPacket.speakerWorld(formatSpeakerMessage(user, String.join("", s1, s2, s3, s4, s5)), user.getChannelId(), whisperIcon));
-                    }
-                }
-                case ADBOARD -> {
-                    final String message = inPacket.decodeString();
-                    user.setAdBoard(message);
-                    user.getField().broadcastPacket(UserPacket.userAdBoard(user, message));
+                // Remove item
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    log.error("Could not remove speaker channel item from inventory");
                     user.dispose();
+                    return;
                 }
-                case CONSUMEEFFECTITEM -> {
-                    // Remove item
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        log.error("Could not remove consume effect item from inventory");
-                        user.dispose();
-                        return;
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), true));
-                    // Show effect
-                    user.write(UserLocal.effect(Effect.consumeEffect(item.getItemId())));
-                    user.getField().broadcastPacket(UserRemote.effect(user, Effect.consumeEffect(item.getItemId())), user);
-                    // Create affected area
-                    final Instant expireTime = Instant.now().plus(itemInfo.getInfo(ItemInfoType.time, 60), ChronoUnit.SECONDS);
-                    user.getField().getAffectedAreaPool().addAffectedArea(AffectedArea.buff(user, item.getItemId(), itemInfo.getRect(), expireTime));
-                }
-                case KARMASCISSORS -> {
-                    // Resolve target item
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), true));
+                // Channel broadcast
+                user.getConnectedServer().submitChannelPacketBroadcast(BroadcastPacket.speakerChannel(message));
+            }
+            case SPEAKERWORLD, SKULLSPEAKER -> {
+                final String message = formatSpeakerMessage(user, inPacket.decodeString());
+                final boolean whisperIcon = inPacket.decodeBoolean();
+                final OutPacket outPacket = cashItemType == CashItemType.SPEAKERWORLD ?
+                        BroadcastPacket.speakerWorld(message, user.getChannelId(), whisperIcon) :
+                        BroadcastPacket.skullSpeaker(message, user.getChannelId(), whisperIcon);
+                handleWorldSpeaker(user, position, item, false, outPacket);
+            }
+            case ITEMSPEAKER -> {
+                final String message = formatSpeakerMessage(user, inPacket.decodeString());
+                final boolean whisperIcon = inPacket.decodeBoolean();
+                final Item targetItem;
+                if (inPacket.decodeBoolean()) {
                     final int targetType = inPacket.decodeInt(); // nTargetTI
                     final int targetPosition = inPacket.decodeInt(); // nTargetPOS
                     final InventoryType inventoryType = InventoryType.getByPosition(InventoryType.getByValue(targetType), targetPosition);
                     if (inventoryType == null) {
-                        log.error("Received unknown target inventory type {} for karma scissors", targetType);
+                        log.error("Received unknown target inventory type {} for item speaker", targetType);
                         user.dispose();
                         return;
                     }
-                    final Item targetItem = im.getInventoryByType(inventoryType).getItem(targetPosition);
-                    if (targetItem == null) {
-                        log.error("Could not resolve item in inventory type {} position {} for karma scissors", inventoryType, targetPosition);
-                        user.dispose();
-                        return;
-                    }
-                    // Remove item
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        log.error("Could not remove karma scissors item from inventory");
-                        user.dispose();
-                        return;
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
-                    // Update target item
-                    targetItem.setPossibleTrading(true);
-                    final Optional<InventoryOperation> updateResult = im.updateItem(targetPosition, targetItem);
-                    if (updateResult.isEmpty()) {
-                        throw new IllegalStateException("Could not update item");
-                    }
-                    user.write(WvsContext.inventoryOperation(updateResult.get(), true));
+                    targetItem = im.getInventoryByType(inventoryType).getItem(targetPosition);
+                } else {
+                    targetItem = null;
                 }
-                case ITEMUPGRADE -> {
-                    final int targetType = inPacket.decodeInt(); // nItemTI
-                    final int targetPosition = inPacket.decodeInt(); // nSlotPosition
-                    inPacket.decodeInt(); // update_time (again)
-                    // Resolve equip item
-                    final InventoryType inventoryType = InventoryType.getByPosition(InventoryType.getByValue(targetType), targetPosition);
-                    if (inventoryType == null) {
-                        log.error("Received unknown target inventory type {} for vicious' hammer", targetType);
-                        user.write(FieldPacket.itemUpgradeResultErr(0)); // Unknown error
-                        return;
-                    }
-                    final Item targetItem = im.getInventoryByType(inventoryType).getItem(targetPosition);
-                    if (targetItem == null) {
-                        log.error("Could not resolve item in inventory type {} position {} for vicious' hammer", inventoryType, targetPosition);
-                        user.write(FieldPacket.itemUpgradeResultErr(0)); // Unknown error
-                        return;
-                    }
-                    final Optional<ItemInfo> targetItemInfoResult = ItemProvider.getItemInfo(targetItem.getItemId());
-                    if (targetItemInfoResult.isEmpty()) {
-                        log.error("Could not resolve item info for target item ID : {}", targetItem.getItemId());
-                        user.write(FieldPacket.itemUpgradeResultErr(0)); // Unknown error
-                        return;
-                    }
-                    final ItemInfo equipItemInfo = targetItemInfoResult.get();
-                    final EquipData equipData = targetItem.getEquipData();
-                    // Check target item
-                    if (equipData == null || equipItemInfo.getInfo(ItemInfoType.tuc) == 0) {
-                        log.error("Tried to vicious' hammer item {} in position {}", targetItem.getItemId(), targetPosition);
-                        user.write(FieldPacket.itemUpgradeResultErr(1)); // The item is not upgradable.
-                        return;
-                    }
-                    if (equipData.getIuc() >= equipItemInfo.getInfo(ItemInfoType.IUCMax, 2)) {
-                        user.write(FieldPacket.itemUpgradeResultErr(2)); // 2 upgrade increases have been used already.
-                        return;
-                    }
-                    if (targetItem.getItemId() == ItemConstants.HORNTAIL_NECKLACE || targetItem.getItemId() == ItemConstants.CHAOS_HORNTAIL_NECKLACE) {
-                        user.write(FieldPacket.itemUpgradeResultErr(3)); // You can't use Vicious' Hammer on Horntail Necklace.
-                        return;
-                    }
-                    // Remove item
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not remove vicious' hammer item %d in position %d", item.getItemId(), position));
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
-                    // Update target item
-                    equipData.setRuc((byte) (equipData.getRuc() + 1));
-                    equipData.setIuc(equipData.getIuc() + 1);
-                    final Optional<InventoryOperation> updateItemResult = im.updateItem(targetPosition, targetItem);
-                    if (updateItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not update equip item %d in position %d", targetItem.getItemId(), targetPosition));
-                    }
-                    user.write(WvsContext.inventoryOperation(updateItemResult.get(), false));
-                    user.write(FieldPacket.itemUpgradeResultSuccess(equipData.getIuc())); // exclRequest by ItemUpgradeResult
+                handleWorldSpeaker(user, position, item, false, BroadcastPacket.itemSpeaker(message, targetItem, user.getChannelId(), whisperIcon));
+            }
+            case ARTSPEAKERWORLD -> {
+                final List<String> messages = new ArrayList<>();
+                final int size = inPacket.decodeByte();
+                for (int i = 0; i < size; i++) {
+                    messages.add(formatSpeakerMessage(user, inPacket.decodeString()));
                 }
-                case ITEM_UNRELEASE -> {
-                    final int equipItemPosition = inPacket.decodeInt();
-                    // Resolve equip item
-                    final InventoryType equipInventoryType = InventoryType.getByPosition(InventoryType.EQUIP, equipItemPosition);
-                    final Item equipItem = im.getInventoryByType(equipInventoryType).getItem(equipItemPosition);
-                    if (equipItem == null) {
-                        log.error("Could not resolve equip item to unrelease in position {}", equipItemPosition);
-                        user.dispose();
+                final boolean whisperIcon = inPacket.decodeBoolean();
+                handleWorldSpeaker(user, position, item, false, BroadcastPacket.artSpeakerWorld(messages, user.getChannelId(), whisperIcon));
+            }
+            case AVATARMEGAPHONE -> {
+                final String s1 = inPacket.decodeString();
+                final String s2 = inPacket.decodeString();
+                final String s3 = inPacket.decodeString();
+                final String s4 = inPacket.decodeString();
+                final boolean whisperIcon = inPacket.decodeBoolean();
+                handleWorldSpeaker(user, position, item, true, WvsContext.avatarMegaphoneUpdateMessage(user, itemId, s1, s2, s3, s4, whisperIcon));
+            }
+            case MAPLETV, MAPLESOLETV, MAPLELOVETV, MEGATV, MEGASOLETV, MEGALOVETV -> {
+                final boolean isMega = cashItemType == CashItemType.MEGATV || cashItemType == CashItemType.MEGASOLETV || cashItemType == CashItemType.MEGALOVETV;
+                final int type = switch (cashItemType) {
+                    case MAPLESOLETV, MEGASOLETV -> 1;
+                    case MAPLELOVETV, MEGALOVETV -> 2;
+                    default -> 0;
+                };
+                final int flag = type == 0 ? inPacket.decodeByte() : (type == 1 ? 1 : 3);
+                final boolean whisperIcon = isMega && inPacket.decodeBoolean();
+                String receiverName = null;
+                AvatarLook receiver = null;
+                if ((flag & 2) != 0) {
+                    receiverName = inPacket.decodeString();
+                    final Optional<User> receiverResult = user.getField().getUserPool().getByCharacterName(receiverName);
+                    if (receiverResult.isEmpty()) {
+                        user.write(WvsContext.mapleTvUseRes("Unable to find the character."));
                         return;
                     }
-                    final Optional<ItemInfo> equipItemInfoResult = ItemProvider.getItemInfo(equipItem.getItemId());
-                    if (equipItemInfoResult.isEmpty()) {
-                        log.error("Could not resolve item info for equip item ID : {}", equipItem.getItemId());
-                        user.dispose();
-                        return;
-                    }
-                    final ItemInfo equipItemInfo = equipItemInfoResult.get();
-                    final EquipData equipData = equipItem.getEquipData();
-                    if (equipData == null || equipData.getGrade() == 0 || !equipData.isReleased()) {
-                        log.error("Tried to unrelease equip item {} in position {}", equipItem.getItemId(), equipItemPosition);
-                        user.dispose();
-                        return;
-                    }
-                    // Resolve item options
-                    ItemGrade itemGrade = equipData.getItemGrade();
-                    if (itemGrade == ItemGrade.RARE && Util.succeedDouble(ItemConstants.POTENTIAL_TIER_UP_EPIC)) {
-                        itemGrade = ItemGrade.EPIC;
-                    }
-                    if (itemGrade == ItemGrade.EPIC && Util.succeedDouble(ItemConstants.POTENTIAL_TIER_UP_UNIQUE)) {
-                        itemGrade = ItemGrade.UNIQUE;
-                    }
-                    final List<ItemOptionInfo> primeItemOptions = ItemProvider.getPossibleItemOptions(equipItemInfo, itemGrade);
-                    final List<ItemOptionInfo> lowerItemOptions = ItemProvider.getPossibleItemOptions(equipItemInfo, itemGrade.getLowerGrade());
-                    if (primeItemOptions.isEmpty() || lowerItemOptions.isEmpty()) {
-                        log.error("Could not resolve item options for grade : {}", equipData.getItemGrade());
-                        user.dispose();
-                        return;
-                    }
-                    // Check user can hold cube fragment
-                    final Optional<ItemInfo> fragmentItemInfoResult = ItemProvider.getItemInfo(ItemConstants.MIRACLE_CUBE_FRAGMENT);
-                    if (fragmentItemInfoResult.isEmpty()) {
-                        log.error("Could not resolve cube fragment item : {}", ItemConstants.MIRACLE_CUBE_FRAGMENT);
-                        user.dispose();
-                        return;
-                    }
-                    final ItemInfo fragmentItemInfo = fragmentItemInfoResult.get();
-                    if (!im.canAddItem(fragmentItemInfo.getItemId(), 1)) {
-                        user.write(UserPacket.userItemUnreleaseEffect(user, false)); // Resetting Potential has failed due to insufficient space in the Use item.
-                        user.dispose();
-                        return;
-                    }
-                    // Consume item
-                    final Optional<InventoryOperation> removeUpgradeItemResult = im.removeItem(position, item, 1);
-                    if (removeUpgradeItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not remove item unrelease item %d in position %d", item.getItemId(), position));
-                    }
-                    user.write(WvsContext.inventoryOperation(removeUpgradeItemResult.get(), false));
-                    // Give cube fragment
-                    final Item fragmentItem = fragmentItemInfo.createItem(user.getNextItemSn(), 1);
-                    final Optional<List<InventoryOperation>> addItemResult = im.addItem(fragmentItem);
-                    if (addItemResult.isEmpty()) {
-                        throw new IllegalStateException("Could not add cube fragment item");
-                    }
-                    user.write(WvsContext.inventoryOperation(addItemResult.get(), false));
-                    // Update item
-                    final boolean secondLine = equipData.getOption2() != 0;
-                    final boolean thirdLine = equipData.getOption3() != 0;
-                    final boolean primeLine2 = Util.succeedProp(ItemConstants.POTENTIAL_PRIME_LINE2_PROP);
-                    final boolean primeLine3 = Util.succeedProp(ItemConstants.POTENTIAL_PRIME_LINE3_PROP);
-                    final int option1 = Util.getRandomFromCollection(primeItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0);
-                    final int option2 = secondLine ? Util.getRandomFromCollection(primeLine2 ? primeItemOptions : lowerItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0) : 0;
-                    final int option3 = thirdLine ? Util.getRandomFromCollection(primeLine3 ? primeItemOptions : lowerItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0) : 0;
-                    equipData.setOption1((short) option1);
-                    equipData.setOption2((short) option2);
-                    equipData.setOption3((short) option3);
-                    equipData.setGrade((byte) itemGrade.getValue());
-                    // Update client
-                    final Optional<InventoryOperation> updateItemResult = im.updateItem(equipItemPosition, equipItem);
-                    if (updateItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not update equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
-                    }
-                    user.write(WvsContext.inventoryOperation(updateItemResult.get(), true));
-                    user.write(UserPacket.userItemUnreleaseEffect(user, true)); // Potential successfully reset. Miracle Cube Fragment obtained!
+                    receiver = receiverResult.get().getCharacterData().getAvatarLook();
                 }
-                case WEATHER -> {
-                    final String message = inPacket.decodeString();
-                    // Consume item
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not remove weather item %d in position %d", item.getItemId(), position));
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), true));
-                    // Blow weather
-                    user.getField().blowWeather(itemId, String.format("%s : %s", user.getCharacterName(), message), 30);
-                    // Apply state change item
-                    final int stateChangeItem = itemInfo.getInfo(ItemInfoType.stateChangeItem);
-                    if (stateChangeItem == 0) {
-                        user.dispose();
+                final String s1 = inPacket.decodeString();
+                final String s2 = inPacket.decodeString();
+                final String s3 = inPacket.decodeString();
+                final String s4 = inPacket.decodeString();
+                final String s5 = inPacket.decodeString();
+                // Check maple tv queue
+                final Instant expireTime;
+                final int duration = type == 0 ? 15 : (type == 1 ? 30 : 60);
+                if (user.getField().getMapleTvQueue().isEmpty()) {
+                    expireTime = Instant.now().plus(duration, ChronoUnit.SECONDS);
+                } else {
+                    final Instant lastExpire = user.getField().getMapleTvQueue().getLast().getExpireTime();
+                    if (lastExpire.isAfter(Instant.now().plus(60, ChronoUnit.SECONDS))) {
+                        user.write(WvsContext.mapleTvUseRes("The waiting line is longer than a minute. Please try using it at a later time."));
                         return;
                     }
-                    final Optional<ItemInfo> stateChangeItemInfoResult = ItemProvider.getItemInfo(stateChangeItem);
-                    if (stateChangeItemInfoResult.isEmpty()) {
-                        log.error("Could not resolve item info for item ID : {}", stateChangeItem);
-                        user.dispose();
-                        return;
+                    expireTime = lastExpire.plus(duration, ChronoUnit.SECONDS);
+                }
+                // Remove item
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    log.error("Could not remove maple tv item from inventory");
+                    user.dispose();
+                    return;
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), true));
+                // Show message
+                final MapleTvMessage message = new MapleTvMessage(
+                        flag,
+                        type,
+                        user.getCharacterData().getAvatarLook(),
+                        user.getCharacterName(),
+                        receiver,
+                        receiverName,
+                        s1,
+                        s2,
+                        s3,
+                        s4,
+                        s5,
+                        expireTime
+                );
+                final int totalWaitTime = (int) Math.max(expireTime.getEpochSecond() - Instant.now().getEpochSecond(), 0);
+                if (user.getField().getMapleTvQueue().isEmpty()) {
+                    user.getField().broadcastPacket(MapleTvPacket.updateMessage(message, totalWaitTime));
+                }
+                user.getField().getMapleTvQueue().addLast(message);
+                if (isMega) {
+                    user.getConnectedServer().submitWorldSpeakerRequest(user.getCharacterId(), false, BroadcastPacket.speakerWorld(formatSpeakerMessage(user, String.join("", s1, s2, s3, s4, s5)), user.getChannelId(), whisperIcon));
+                }
+            }
+            case ADBOARD -> {
+                final String message = inPacket.decodeString();
+                user.setAdBoard(message);
+                user.getField().broadcastPacket(UserPacket.userAdBoard(user, message));
+                user.dispose();
+            }
+            case CONSUMEEFFECTITEM -> {
+                // Remove item
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    log.error("Could not remove consume effect item from inventory");
+                    user.dispose();
+                    return;
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), true));
+                // Show effect
+                user.write(UserLocal.effect(Effect.consumeEffect(item.getItemId())));
+                user.getField().broadcastPacket(UserRemote.effect(user, Effect.consumeEffect(item.getItemId())), user);
+                // Create affected area
+                final Instant expireTime = Instant.now().plus(itemInfo.getInfo(ItemInfoType.time, 60), ChronoUnit.SECONDS);
+                user.getField().getAffectedAreaPool().addAffectedArea(AffectedArea.buff(user, item.getItemId(), itemInfo.getRect(), expireTime));
+            }
+            case KARMASCISSORS -> {
+                // Resolve target item
+                final int targetType = inPacket.decodeInt(); // nTargetTI
+                final int targetPosition = inPacket.decodeInt(); // nTargetPOS
+                final InventoryType inventoryType = InventoryType.getByPosition(InventoryType.getByValue(targetType), targetPosition);
+                if (inventoryType == null) {
+                    log.error("Received unknown target inventory type {} for karma scissors", targetType);
+                    user.dispose();
+                    return;
+                }
+                final Item targetItem = im.getInventoryByType(inventoryType).getItem(targetPosition);
+                if (targetItem == null) {
+                    log.error("Could not resolve item in inventory type {} position {} for karma scissors", inventoryType, targetPosition);
+                    user.dispose();
+                    return;
+                }
+                // Remove item
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    log.error("Could not remove karma scissors item from inventory");
+                    user.dispose();
+                    return;
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
+                // Update target item
+                targetItem.setPossibleTrading(true);
+                final Optional<InventoryOperation> updateResult = im.updateItem(targetPosition, targetItem);
+                if (updateResult.isEmpty()) {
+                    throw new IllegalStateException("Could not update item");
+                }
+                user.write(WvsContext.inventoryOperation(updateResult.get(), true));
+            }
+            case ITEMUPGRADE -> {
+                final int targetType = inPacket.decodeInt(); // nItemTI
+                final int targetPosition = inPacket.decodeInt(); // nSlotPosition
+                inPacket.decodeInt(); // update_time (again)
+                // Resolve equip item
+                final InventoryType inventoryType = InventoryType.getByPosition(InventoryType.getByValue(targetType), targetPosition);
+                if (inventoryType == null) {
+                    log.error("Received unknown target inventory type {} for vicious' hammer", targetType);
+                    user.write(FieldPacket.itemUpgradeResultErr(0)); // Unknown error
+                    return;
+                }
+                final Item targetItem = im.getInventoryByType(inventoryType).getItem(targetPosition);
+                if (targetItem == null) {
+                    log.error("Could not resolve item in inventory type {} position {} for vicious' hammer", inventoryType, targetPosition);
+                    user.write(FieldPacket.itemUpgradeResultErr(0)); // Unknown error
+                    return;
+                }
+                final Optional<ItemInfo> targetItemInfoResult = ItemProvider.getItemInfo(targetItem.getItemId());
+                if (targetItemInfoResult.isEmpty()) {
+                    log.error("Could not resolve item info for target item ID : {}", targetItem.getItemId());
+                    user.write(FieldPacket.itemUpgradeResultErr(0)); // Unknown error
+                    return;
+                }
+                final ItemInfo equipItemInfo = targetItemInfoResult.get();
+                final EquipData equipData = targetItem.getEquipData();
+                // Check target item
+                if (equipData == null || equipItemInfo.getInfo(ItemInfoType.tuc) == 0) {
+                    log.error("Tried to vicious' hammer item {} in position {}", targetItem.getItemId(), targetPosition);
+                    user.write(FieldPacket.itemUpgradeResultErr(1)); // The item is not upgradable.
+                    return;
+                }
+                if (equipData.getIuc() >= equipItemInfo.getInfo(ItemInfoType.IUCMax, 2)) {
+                    user.write(FieldPacket.itemUpgradeResultErr(2)); // 2 upgrade increases have been used already.
+                    return;
+                }
+                if (targetItem.getItemId() == ItemConstants.HORNTAIL_NECKLACE || targetItem.getItemId() == ItemConstants.CHAOS_HORNTAIL_NECKLACE) {
+                    user.write(FieldPacket.itemUpgradeResultErr(3)); // You can't use Vicious' Hammer on Horntail Necklace.
+                    return;
+                }
+                // Remove item
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not remove vicious' hammer item %d in position %d", item.getItemId(), position));
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
+                // Update target item
+                equipData.setRuc((byte) (equipData.getRuc() + 1));
+                equipData.setIuc(equipData.getIuc() + 1);
+                final Optional<InventoryOperation> updateItemResult = im.updateItem(targetPosition, targetItem);
+                if (updateItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not update equip item %d in position %d", targetItem.getItemId(), targetPosition));
+                }
+                user.write(WvsContext.inventoryOperation(updateItemResult.get(), false));
+                user.write(FieldPacket.itemUpgradeResultSuccess(equipData.getIuc())); // exclRequest by ItemUpgradeResult
+            }
+            case ITEM_UNRELEASE -> {
+                final int equipItemPosition = inPacket.decodeInt();
+                // Resolve equip item
+                final InventoryType equipInventoryType = InventoryType.getByPosition(InventoryType.EQUIP, equipItemPosition);
+                final Item equipItem = im.getInventoryByType(equipInventoryType).getItem(equipItemPosition);
+                if (equipItem == null) {
+                    log.error("Could not resolve equip item to unrelease in position {}", equipItemPosition);
+                    user.dispose();
+                    return;
+                }
+                final Optional<ItemInfo> equipItemInfoResult = ItemProvider.getItemInfo(equipItem.getItemId());
+                if (equipItemInfoResult.isEmpty()) {
+                    log.error("Could not resolve item info for equip item ID : {}", equipItem.getItemId());
+                    user.dispose();
+                    return;
+                }
+                final ItemInfo equipItemInfo = equipItemInfoResult.get();
+                final EquipData equipData = equipItem.getEquipData();
+                if (equipData == null || equipData.getGrade() == 0 || !equipData.isReleased()) {
+                    log.error("Tried to unrelease equip item {} in position {}", equipItem.getItemId(), equipItemPosition);
+                    user.dispose();
+                    return;
+                }
+                // Resolve item options
+                ItemGrade itemGrade = equipData.getItemGrade();
+                if (itemGrade == ItemGrade.RARE && Util.succeedDouble(ItemConstants.POTENTIAL_TIER_UP_EPIC)) {
+                    itemGrade = ItemGrade.EPIC;
+                }
+                if (itemGrade == ItemGrade.EPIC && Util.succeedDouble(ItemConstants.POTENTIAL_TIER_UP_UNIQUE)) {
+                    itemGrade = ItemGrade.UNIQUE;
+                }
+                final List<ItemOptionInfo> primeItemOptions = ItemProvider.getPossibleItemOptions(equipItemInfo, itemGrade);
+                final List<ItemOptionInfo> lowerItemOptions = ItemProvider.getPossibleItemOptions(equipItemInfo, itemGrade.getLowerGrade());
+                if (primeItemOptions.isEmpty() || lowerItemOptions.isEmpty()) {
+                    log.error("Could not resolve item options for grade : {}", equipData.getItemGrade());
+                    user.dispose();
+                    return;
+                }
+                // Check user can hold cube fragment
+                final Optional<ItemInfo> fragmentItemInfoResult = ItemProvider.getItemInfo(ItemConstants.MIRACLE_CUBE_FRAGMENT);
+                if (fragmentItemInfoResult.isEmpty()) {
+                    log.error("Could not resolve cube fragment item : {}", ItemConstants.MIRACLE_CUBE_FRAGMENT);
+                    user.dispose();
+                    return;
+                }
+                final ItemInfo fragmentItemInfo = fragmentItemInfoResult.get();
+                if (!im.canAddItem(fragmentItemInfo.getItemId(), 1)) {
+                    user.write(UserPacket.userItemUnreleaseEffect(user, false)); // Resetting Potential has failed due to insufficient space in the Use item.
+                    user.dispose();
+                    return;
+                }
+                // Consume item
+                final Optional<InventoryOperation> removeUpgradeItemResult = im.removeItem(position, item, 1);
+                if (removeUpgradeItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not remove item unrelease item %d in position %d", item.getItemId(), position));
+                }
+                user.write(WvsContext.inventoryOperation(removeUpgradeItemResult.get(), false));
+                // Give cube fragment
+                final Item fragmentItem = fragmentItemInfo.createItem(user.getNextItemSn(), 1);
+                final Optional<List<InventoryOperation>> addItemResult = im.addItem(fragmentItem);
+                if (addItemResult.isEmpty()) {
+                    throw new IllegalStateException("Could not add cube fragment item");
+                }
+                user.write(WvsContext.inventoryOperation(addItemResult.get(), false));
+                // Update item
+                final boolean secondLine = equipData.getOption2() != 0;
+                final boolean thirdLine = equipData.getOption3() != 0;
+                final boolean primeLine2 = Util.succeedProp(ItemConstants.POTENTIAL_PRIME_LINE2_PROP);
+                final boolean primeLine3 = Util.succeedProp(ItemConstants.POTENTIAL_PRIME_LINE3_PROP);
+                final int option1 = Util.getRandomFromCollection(primeItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0);
+                final int option2 = secondLine ? Util.getRandomFromCollection(primeLine2 ? primeItemOptions : lowerItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0) : 0;
+                final int option3 = thirdLine ? Util.getRandomFromCollection(primeLine3 ? primeItemOptions : lowerItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0) : 0;
+                equipData.setOption1((short) option1);
+                equipData.setOption2((short) option2);
+                equipData.setOption3((short) option3);
+                equipData.setGrade((byte) itemGrade.getValue());
+                // Update client
+                final Optional<InventoryOperation> updateItemResult = im.updateItem(equipItemPosition, equipItem);
+                if (updateItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not update equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
+                }
+                user.write(WvsContext.inventoryOperation(updateItemResult.get(), true));
+                user.write(UserPacket.userItemUnreleaseEffect(user, true)); // Potential successfully reset. Miracle Cube Fragment obtained!
+            }
+            case WEATHER -> {
+                final String message = inPacket.decodeString();
+                // Consume item
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not remove weather item %d in position %d", item.getItemId(), position));
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), true));
+                // Blow weather
+                user.getField().blowWeather(itemId, String.format("%s : %s", user.getCharacterName(), message), 30);
+                // Apply state change item
+                final int stateChangeItem = itemInfo.getInfo(ItemInfoType.stateChangeItem);
+                if (stateChangeItem == 0) {
+                    user.dispose();
+                    return;
+                }
+                final Optional<ItemInfo> stateChangeItemInfoResult = ItemProvider.getItemInfo(stateChangeItem);
+                if (stateChangeItemInfoResult.isEmpty()) {
+                    log.error("Could not resolve item info for item ID : {}", stateChangeItem);
+                    user.dispose();
+                    return;
+                }
+                final ItemInfo stateChangeItemInfo = stateChangeItemInfoResult.get();
+                changeStat(user, stateChangeItemInfo);
+                user.getField().getUserPool().forEach((other) -> {
+                    if (other.getCharacterId() != user.getCharacterId()) {
+                        changeStat(other, stateChangeItemInfo);
                     }
-                    final ItemInfo stateChangeItemInfo = stateChangeItemInfoResult.get();
-                    changeStat(locked, stateChangeItemInfo);
-                    user.getField().getUserPool().forEach((other) -> {
-                        if (other.getCharacterId() != user.getCharacterId()) {
-                            try (var lockedOther = other.acquire()) {
-                                changeStat(lockedOther, stateChangeItemInfo);
-                            }
+                });
+            }
+            case SETPETNAME -> {
+                final String petName = inPacket.decodeString();
+                // Resolve pet
+                final Pet pet = user.getPet(0);
+                if (pet == null) {
+                    log.error("Could not resolve target for pet name change");
+                    user.dispose();
+                    return;
+                }
+                // Resolve pet item
+                final Optional<Map.Entry<Integer, Item>> itemEntry = im.getCashInventory().getItems().entrySet().stream()
+                        .filter((entry) -> entry.getValue().getItemSn() == pet.getItemSn())
+                        .findFirst();
+                if (itemEntry.isEmpty()) {
+                    throw new IllegalStateException("Could not resolve target pet item");
+                }
+                final int petPosition = itemEntry.get().getKey();
+                final Item petItem = itemEntry.get().getValue();
+                // Consume item
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not remove weather item %d in position %d", item.getItemId(), position));
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
+                // Set pet name and update item
+                petItem.getPetData().setPetName(petName);
+                final Optional<InventoryOperation> updateResult = im.updateItem(petPosition, petItem);
+                if (updateResult.isEmpty()) {
+                    throw new IllegalStateException("Could not update pet item");
+                }
+                user.write(WvsContext.inventoryOperation(updateResult.get(), true));
+                user.getField().broadcastPacket(PetPacket.petNameChanged(user, pet.getPetIndex(), petName));
+            }
+            case SELECTNPC -> {
+                final int npcId = itemInfo.getInfo(ItemInfoType.npc);
+                // Resolve npc
+                final Optional<NpcTemplate> npcTemplateResult = NpcProvider.getNpcTemplate(npcId);
+                if (npcTemplateResult.isEmpty()) {
+                    log.error("Could not resolve npc ID {} for item ID : {}", npcId, itemId);
+                    user.dispose();
+                    return;
+                }
+                final NpcTemplate npcTemplate = npcTemplateResult.get();
+                // Check if dialog present
+                if (user.hasDialog()) {
+                    log.error("Tried to use select npc item ID {}, while already in a dialog", itemId);
+                    user.dispose();
+                    return;
+                }
+                // Consume item
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not remove select npc item %d in position %d", item.getItemId(), position));
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
+                if (npcTemplate.isTrunk()) {
+                    final TrunkDialog trunkDialog = TrunkDialog.from(npcTemplate);
+                    user.setDialog(trunkDialog);
+                    user.write(TrunkPacket.openTrunkDlg(npcId, user.getAccount().getTrunk()));
+                } else {
+                    final ShopDialog shopDialog = ShopDialog.from(npcTemplate);
+                    user.setDialog(shopDialog);
+                    user.write(FieldPacket.openShopDlg(user, shopDialog));
+                }
+            }
+            case MORPH -> {
+                // Consume item and change stat
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not remove morph item %d in position %d", item.getItemId(), position));
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
+                changeStat(user, itemInfo);
+            }
+            case MAPTRANSFER -> {
+                final boolean targetUser = inPacket.decodeBoolean();
+                if (targetUser) {
+                    // Resolve target location
+                    final String targetName = inPacket.decodeString();
+                    user.getConnectedServer().submitUserQueryRequest(List.of(targetName), (queryResult) -> {
+                        final Optional<RemoteUser> targetResult = queryResult.stream().findFirst();
+                        if (targetResult.isEmpty()) {
+                            user.write(MapTransferPacket.targetNotExist()); // %s is currently difficult to locate, so the teleport will not take place.
+                            user.dispose();
+                            return;
                         }
+                        final RemoteUser target = targetResult.get();
+                        if (target.getChannelId() != user.getChannelId()) {
+                            user.write(MapTransferPacket.targetNotExist()); // %s is currently difficult to locate, so the teleport will not take place.
+                            user.dispose();
+                            return;
+                        }
+                        handleMapTransfer(user, target.getFieldId(), item, position);
                     });
-                }
-                case SETPETNAME -> {
-                    final String petName = inPacket.decodeString();
-                    // Resolve pet
-                    final Pet pet = user.getPet(0);
-                    if (pet == null) {
-                        log.error("Could not resolve target for pet name change");
+                } else {
+                    final int targetField = inPacket.decodeInt(); // dwTargetField
+                    final List<Integer> availableFields = itemId / 1000 != 5040 ? // canTransferContinent
+                            user.getMapTransferInfo().getMapTransferEx() :
+                            user.getMapTransferInfo().getMapTransfer();
+                    if (!availableFields.contains(targetField)) {
+                        user.write(MapTransferPacket.unknown()); // You cannot go to that place.
                         user.dispose();
                         return;
                     }
-                    // Resolve pet item
-                    final Optional<Map.Entry<Integer, Item>> itemEntry = im.getCashInventory().getItems().entrySet().stream()
-                            .filter((entry) -> entry.getValue().getItemSn() == pet.getItemSn())
-                            .findFirst();
-                    if (itemEntry.isEmpty()) {
-                        throw new IllegalStateException("Could not resolve target pet item");
-                    }
-                    final int petPosition = itemEntry.get().getKey();
-                    final Item petItem = itemEntry.get().getValue();
-                    // Consume item
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not remove weather item %d in position %d", item.getItemId(), position));
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
-                    // Set pet name and update item
-                    petItem.getPetData().setPetName(petName);
-                    final Optional<InventoryOperation> updateResult = im.updateItem(petPosition, petItem);
-                    if (updateResult.isEmpty()) {
-                        throw new IllegalStateException("Could not update pet item");
-                    }
-                    user.write(WvsContext.inventoryOperation(updateResult.get(), true));
-                    user.getField().broadcastPacket(PetPacket.petNameChanged(user, pet.getPetIndex(), petName));
+                    handleMapTransfer(user, targetField, item, position);
                 }
-                case SELECTNPC -> {
-                    final int npcId = itemInfo.getInfo(ItemInfoType.npc);
-                    // Resolve npc
-                    final Optional<NpcTemplate> npcTemplateResult = NpcProvider.getNpcTemplate(npcId);
-                    if (npcTemplateResult.isEmpty()) {
-                        log.error("Could not resolve npc ID {} for item ID : {}", npcId, itemId);
-                        user.dispose();
-                        return;
-                    }
-                    final NpcTemplate npcTemplate = npcTemplateResult.get();
-                    // Check if dialog present
-                    if (user.hasDialog()) {
-                        log.error("Tried to use select npc item ID {}, while already in a dialog", itemId);
-                        user.dispose();
-                        return;
-                    }
-                    // Consume item
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not remove select npc item %d in position %d", item.getItemId(), position));
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
-                    if (npcTemplate.isTrunk()) {
-                        final TrunkDialog trunkDialog = TrunkDialog.from(npcTemplate);
-                        user.setDialog(trunkDialog);
-                        // Lock account to access trunk
-                        try (var lockedAccount = user.getAccount().acquire()) {
-                            user.write(TrunkPacket.openTrunkDlg(npcId, lockedAccount.get().getTrunk()));
-                        }
-                    } else {
-                        final ShopDialog shopDialog = ShopDialog.from(npcTemplate);
-                        user.setDialog(shopDialog);
-                        user.write(FieldPacket.openShopDlg(user, shopDialog));
-                    }
-                }
-                case MORPH -> {
-                    // Consume item and change stat
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not remove morph item %d in position %d", item.getItemId(), position));
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
-                    changeStat(locked, itemInfo);
-                }
-                case MAPTRANSFER -> {
-                    final boolean targetUser = inPacket.decodeBoolean();
-                    if (targetUser) {
-                        // Resolve target location
-                        final String targetName = inPacket.decodeString();
-                        user.getConnectedServer().submitUserQueryRequest(List.of(targetName), (queryResult) -> {
-                            final Optional<RemoteUser> targetResult = queryResult.stream().findFirst();
-                            if (targetResult.isEmpty()) {
-                                user.write(MapTransferPacket.targetNotExist()); // %s is currently difficult to locate, so the teleport will not take place.
-                                user.dispose();
-                                return;
-                            }
-                            final RemoteUser target = targetResult.get();
-                            if (target.getChannelId() != user.getChannelId()) {
-                                user.write(MapTransferPacket.targetNotExist()); // %s is currently difficult to locate, so the teleport will not take place.
-                                user.dispose();
-                                return;
-                            }
-                            handleMapTransfer(user, target.getFieldId(), item, position);
-                        });
-                    } else {
-                        final int targetField = inPacket.decodeInt(); // dwTargetField
-                        final List<Integer> availableFields = itemId / 1000 != 5040 ? // canTransferContinent
-                                user.getMapTransferInfo().getMapTransferEx() :
-                                user.getMapTransferInfo().getMapTransfer();
-                        if (!availableFields.contains(targetField)) {
-                            user.write(MapTransferPacket.unknown()); // You cannot go to that place.
-                            user.dispose();
-                            return;
-                        }
-                        handleMapTransfer(user, targetField, item, position);
-                    }
-                }
-                case STATCHANGE -> {
-                    final int inc = inPacket.decodeInt(); // dwInc
-                    final int dec = inPacket.decodeInt(); // dwDec
-                    // Validate stats
-                    final Stat incStat = Stat.getByValue(inc);
-                    final Stat decStat = Stat.getByValue(dec);
-                    final CharacterStat cs = user.getCharacterStat();
-                    if (incStat == null || !StatConstants.isAbilityUpStat(incStat) || decStat == null || !StatConstants.isAbilityUpStat(decStat) ||
-                            incStat == decStat || !cs.isValidAp(incStat, 1) || !cs.isValidAp(decStat, -1)) {
-                        log.error("Received invalid stats {}, {} for stat change item ID : {}", inc, dec, itemId);
-                        user.dispose();
-                        return;
-                    }
-                    if (decStat == Stat.MHP || decStat == Stat.MMP) {
-                        final int currentAp = cs.getBaseStr() + cs.getBaseDex() + cs.getBaseInt() + cs.getBaseLuk() + cs.getAp();
-                        final int expectedAp = StatConstants.getSumAp(cs.getLevel(), cs.getJob(), cs.getSubJob());
-                        if (currentAp >= expectedAp) {
-                            log.error("Tried to remove hp/mp without enough ap - current : {}, expected : {}", currentAp, expectedAp);
-                            user.dispose();
-                            return;
-                        }
-                    }
-                    // Consume item
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not remove stat change item %d in position %d", item.getItemId(), position));
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
-                    // Add stats
-                    final Map<Stat, Object> statMap = new EnumMap<>(Stat.class);
-                    statMap.putAll(cs.removeAp(decStat));
-                    statMap.putAll(cs.addAp(incStat, user.getBasicStat().getInt()));
-                    // Update client
-                    user.validateStat();
-                    user.write(WvsContext.statChanged(statMap, true));
-                }
-                case COLORLENS -> {
-                    // Resolve face
-                    final int face = user.getCharacterStat().getFace();
-                    final int color = (face % 1000) - (face % 100);
-                    final int newFace = (face - color) + ((itemId - 5152100) * 100);
-                    if (ItemProvider.getItemInfo(newFace).isEmpty()) {
-                        log.error("Tried to change use color lens to change to face {} using item ID : {}", newFace, itemId);
-                        user.write(BroadcastPacket.alert("This request has failed due to an unknown error."));
-                        return;
-                    }
-                    // Consume item
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not remove color lens item %d in position %d", item.getItemId(), position));
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
-                    // Change avatar
-                    user.getCharacterStat().setFace(newFace);
-                    user.write(WvsContext.statChanged(Stat.FACE, user.getCharacterStat().getFace(), true));
-                    user.getField().broadcastPacket(UserRemote.avatarModified(user), user);
-                }
-                case REWARD -> {
-                    // Resolve reward info
-                    final Optional<ItemRewardInfo> itemRewardInfoResult = ItemProvider.getItemRewardInfo(itemId);
-                    if (itemRewardInfoResult.isEmpty()) {
-                        log.error("Could not resolve reward info for item ID : {}", itemId);
-                        user.dispose();
-                        return;
-                    }
-                    final ItemRewardInfo itemRewardInfo = itemRewardInfoResult.get();
-                    // Resolve reward
-                    if (!itemRewardInfo.canAddReward(locked)) {
-                        user.write(MessagePacket.system("You do not have enough inventory space."));
-                        user.dispose();
-                        return;
-                    }
-                    final Optional<ItemRewardEntry> rewardResult = Util.getRandomFromCollection(itemRewardInfo.getEntries(), ItemRewardEntry::getProbability);
-                    if (rewardResult.isEmpty()) {
-                        log.error("Could not resolve lottery item reward for item {}", itemId);
-                        return;
-                    }
-                    final ItemRewardEntry rewardEntry = rewardResult.get();
-                    final Optional<ItemInfo> rewardItemInfoResult = ItemProvider.getItemInfo(rewardEntry.getItemId());
-                    if (rewardItemInfoResult.isEmpty()) {
-                        log.error("Could not resolve item info for item ID : {}", rewardEntry.getItemId());
-                        return;
-                    }
-                    // Consume item
-                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
-                    if (removeItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not remove reward item %d in position %d", item.getItemId(), position));
-                    }
-                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
-                    // Add reward item
-                    final Item rewardItem = rewardItemInfoResult.get().createItem(user.getNextItemSn(), rewardEntry.getCount());
-                    if (rewardEntry.getPeriod() > 0) {
-                        rewardItem.setDateExpire(Instant.now().plus(rewardEntry.getPeriod(), ChronoUnit.MINUTES));
-                    }
-                    final Optional<List<InventoryOperation>> addResult = user.getInventoryManager().addItem(rewardItem);
-                    if (addResult.isEmpty()) {
-                        throw new IllegalStateException("Could not add reward item to inventory");
-                    }
-                    user.write(WvsContext.inventoryOperation(addResult.get(), true));
-                    if (rewardEntry.hasEffect()) {
-                        user.write(UserLocal.effect(Effect.lotteryUse(itemId, rewardEntry.getEffect())));
-                    }
-                }
-                case null -> {
-                    log.error("Unknown cash item type for item ID : {}", item.getItemId());
+            }
+            case STATCHANGE -> {
+                final int inc = inPacket.decodeInt(); // dwInc
+                final int dec = inPacket.decodeInt(); // dwDec
+                // Validate stats
+                final Stat incStat = Stat.getByValue(inc);
+                final Stat decStat = Stat.getByValue(dec);
+                final CharacterStat cs = user.getCharacterStat();
+                if (incStat == null || !StatConstants.isAbilityUpStat(incStat) || decStat == null || !StatConstants.isAbilityUpStat(decStat) ||
+                        incStat == decStat || !cs.isValidAp(incStat, 1) || !cs.isValidAp(decStat, -1)) {
+                    log.error("Received invalid stats {}, {} for stat change item ID : {}", inc, dec, itemId);
                     user.dispose();
+                    return;
                 }
-                default -> {
-                    log.error("Unhandled cash item type {} for item ID : {}", cashItemType, item.getItemId());
+                if (decStat == Stat.MHP || decStat == Stat.MMP) {
+                    final int currentAp = cs.getBaseStr() + cs.getBaseDex() + cs.getBaseInt() + cs.getBaseLuk() + cs.getAp();
+                    final int expectedAp = StatConstants.getSumAp(cs.getLevel(), cs.getJob(), cs.getSubJob());
+                    if (currentAp >= expectedAp) {
+                        log.error("Tried to remove hp/mp without enough ap - current : {}, expected : {}", currentAp, expectedAp);
+                        user.dispose();
+                        return;
+                    }
+                }
+                // Consume item
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not remove stat change item %d in position %d", item.getItemId(), position));
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
+                // Add stats
+                final Map<Stat, Object> statMap = new EnumMap<>(Stat.class);
+                statMap.putAll(cs.removeAp(decStat));
+                statMap.putAll(cs.addAp(incStat, user.getBasicStat().getInt()));
+                // Update client
+                user.validateStat();
+                user.write(WvsContext.statChanged(statMap, true));
+            }
+            case COLORLENS -> {
+                // Resolve face
+                final int face = user.getCharacterStat().getFace();
+                final int color = (face % 1000) - (face % 100);
+                final int newFace = (face - color) + ((itemId - 5152100) * 100);
+                if (ItemProvider.getItemInfo(newFace).isEmpty()) {
+                    log.error("Tried to change use color lens to change to face {} using item ID : {}", newFace, itemId);
+                    user.write(BroadcastPacket.alert("This request has failed due to an unknown error."));
+                    return;
+                }
+                // Consume item
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not remove color lens item %d in position %d", item.getItemId(), position));
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
+                // Change avatar
+                user.getCharacterStat().setFace(newFace);
+                user.write(WvsContext.statChanged(Stat.FACE, user.getCharacterStat().getFace(), true));
+                user.getField().broadcastPacket(UserRemote.avatarModified(user), user);
+            }
+            case REWARD -> {
+                // Resolve reward info
+                final Optional<ItemRewardInfo> itemRewardInfoResult = ItemProvider.getItemRewardInfo(itemId);
+                if (itemRewardInfoResult.isEmpty()) {
+                    log.error("Could not resolve reward info for item ID : {}", itemId);
                     user.dispose();
+                    return;
                 }
+                final ItemRewardInfo itemRewardInfo = itemRewardInfoResult.get();
+                // Resolve reward
+                if (!itemRewardInfo.canAddReward(user)) {
+                    user.write(MessagePacket.system("You do not have enough inventory space."));
+                    user.dispose();
+                    return;
+                }
+                final Optional<ItemRewardEntry> rewardResult = Util.getRandomFromCollection(itemRewardInfo.getEntries(), ItemRewardEntry::getProbability);
+                if (rewardResult.isEmpty()) {
+                    log.error("Could not resolve lottery item reward for item {}", itemId);
+                    return;
+                }
+                final ItemRewardEntry rewardEntry = rewardResult.get();
+                final Optional<ItemInfo> rewardItemInfoResult = ItemProvider.getItemInfo(rewardEntry.getItemId());
+                if (rewardItemInfoResult.isEmpty()) {
+                    log.error("Could not resolve item info for item ID : {}", rewardEntry.getItemId());
+                    return;
+                }
+                // Consume item
+                final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item, 1);
+                if (removeItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not remove reward item %d in position %d", item.getItemId(), position));
+                }
+                user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
+                // Add reward item
+                final Item rewardItem = rewardItemInfoResult.get().createItem(user.getNextItemSn(), rewardEntry.getCount());
+                if (rewardEntry.getPeriod() > 0) {
+                    rewardItem.setDateExpire(Instant.now().plus(rewardEntry.getPeriod(), ChronoUnit.MINUTES));
+                }
+                final Optional<List<InventoryOperation>> addResult = user.getInventoryManager().addItem(rewardItem);
+                if (addResult.isEmpty()) {
+                    throw new IllegalStateException("Could not add reward item to inventory");
+                }
+                user.write(WvsContext.inventoryOperation(addResult.get(), true));
+                if (rewardEntry.hasEffect()) {
+                    user.write(UserLocal.effect(Effect.lotteryUse(itemId, rewardEntry.getEffect())));
+                }
+            }
+            case null -> {
+                log.error("Unknown cash item type for item ID : {}", item.getItemId());
+                user.dispose();
+            }
+            default -> {
+                log.error("Unhandled cash item type {} for item ID : {}", cashItemType, item.getItemId());
+                user.dispose();
             }
         }
     }

--- a/src/main/java/kinoko/handler/user/item/ItemHandler.java
+++ b/src/main/java/kinoko/handler/user/item/ItemHandler.java
@@ -16,10 +16,8 @@ import kinoko.provider.map.PortalInfo;
 import kinoko.provider.mob.MobTemplate;
 import kinoko.provider.skill.SkillInfo;
 import kinoko.script.common.ScriptDispatcher;
-import kinoko.server.field.InstanceFieldStorage;
 import kinoko.server.header.InHeader;
 import kinoko.server.packet.InPacket;
-import kinoko.util.Locked;
 import kinoko.util.Tuple;
 import kinoko.util.Util;
 import kinoko.world.GameConstants;
@@ -59,34 +57,30 @@ public abstract class ItemHandler {
             return;
         }
 
-        try (var locked = user.acquire()) {
-            // Check field limit
-            final Field field = locked.get().getField();
-            if (field.hasFieldOption(FieldOption.STATCHANGEITEMCONSUMELIMIT) && !field.getMapInfo().getAllowedItems().contains(itemId)) {
-                log.error("Tried to use stat change item in a restricted field");
-                user.dispose();
-                return;
-            }
-
-            // Consume item
-            final Optional<InventoryOperation> consumeItemResult = consumeItem(locked, position, itemId);
-            if (consumeItemResult.isEmpty()) {
-                user.dispose();
-                return;
-            }
-            user.write(WvsContext.inventoryOperation(consumeItemResult.get(), true));
-
-            // Apply stat change
-            changeStat(locked, itemInfoResult.get());
+        // Check field limit
+        final Field field = user.getField();
+        if (field.hasFieldOption(FieldOption.STATCHANGEITEMCONSUMELIMIT) && !field.getMapInfo().getAllowedItems().contains(itemId)) {
+            log.error("Tried to use stat change item in a restricted field");
+            user.dispose();
+            return;
         }
+
+        // Consume item
+        final Optional<InventoryOperation> consumeItemResult = consumeItem(user, position, itemId);
+        if (consumeItemResult.isEmpty()) {
+            user.dispose();
+            return;
+        }
+        user.write(WvsContext.inventoryOperation(consumeItemResult.get(), true));
+
+        // Apply stat change
+        changeStat(user, itemInfoResult.get());
     }
 
     @Handler(InHeader.UserStatChangeItemCancelRequest)
     public static void handleUserStatChangeItemCancelRequest(User user, InPacket inPacket) {
         final int itemId = inPacket.decodeInt(); // sign inverted
-        try (var locked = user.acquire()) {
-            locked.get().resetTemporaryStat(itemId);
-        }
+        user.resetTemporaryStat(itemId);
     }
 
     @Handler(InHeader.UserStatChangeByPortableChairRequest)
@@ -115,45 +109,43 @@ public abstract class ItemHandler {
             return;
         }
 
-        try (var locked = user.acquire()) {
-            // Check field limit
-            final Field field = locked.get().getField();
-            if (field.hasFieldOption(FieldOption.SUMMONLIMIT) && !field.getMapInfo().getAllowedItems().contains(itemId)) {
-                log.error("Tried to use mob summon item in a restricted field");
-                user.dispose();
-                return;
-            }
-            final Optional<Foothold> footholdResult = field.getFootholdBelow(user.getX(), user.getY());
+        // Check field limit
+        final Field field = user.getField();
+        if (field.hasFieldOption(FieldOption.SUMMONLIMIT) && !field.getMapInfo().getAllowedItems().contains(itemId)) {
+            log.error("Tried to use mob summon item in a restricted field");
+            user.dispose();
+            return;
+        }
+        final Optional<Foothold> footholdResult = field.getFootholdBelow(user.getX(), user.getY());
 
-            // Consume item
-            final Optional<InventoryOperation> consumeItemResult = consumeItem(locked, position, itemId);
-            if (consumeItemResult.isEmpty()) {
-                user.dispose();
-                return;
-            }
-            user.write(WvsContext.inventoryOperation(consumeItemResult.get(), true));
+        // Consume item
+        final Optional<InventoryOperation> consumeItemResult = consumeItem(user, position, itemId);
+        if (consumeItemResult.isEmpty()) {
+            user.dispose();
+            return;
+        }
+        user.write(WvsContext.inventoryOperation(consumeItemResult.get(), true));
 
-            // Summon mobs
-            for (Tuple<Integer, Integer> entry : mobSummonInfoResult.get().getEntries()) {
-                final int templateId = entry.getLeft();
-                final int prop = entry.getRight();
-                if (!Util.succeedProp(prop)) {
-                    continue;
-                }
-                final Optional<MobTemplate> mobTemplateResult = MobProvider.getMobTemplate(templateId);
-                if (mobTemplateResult.isEmpty()) {
-                    log.error("Could not resolve mob template ID : {}", templateId);
-                    continue;
-                }
-                final Mob mob = new Mob(
-                        mobTemplateResult.get(),
-                        null,
-                        user.getX(),
-                        user.getY(),
-                        footholdResult.map(Foothold::getSn).orElse(user.getFoothold())
-                );
-                field.getMobPool().addMob(mob);
+        // Summon mobs
+        for (Tuple<Integer, Integer> entry : mobSummonInfoResult.get().getEntries()) {
+            final int templateId = entry.getLeft();
+            final int prop = entry.getRight();
+            if (!Util.succeedProp(prop)) {
+                continue;
             }
+            final Optional<MobTemplate> mobTemplateResult = MobProvider.getMobTemplate(templateId);
+            if (mobTemplateResult.isEmpty()) {
+                log.error("Could not resolve mob template ID : {}", templateId);
+                continue;
+            }
+            final Mob mob = new Mob(
+                    mobTemplateResult.get(),
+                    null,
+                    user.getX(),
+                    user.getY(),
+                    footholdResult.map(Foothold::getSn).orElse(user.getFoothold())
+            );
+            field.getMobPool().addMob(mob);
         }
     }
 
@@ -180,89 +172,87 @@ public abstract class ItemHandler {
         final ItemInfo ii = itemInfoResult.get();
         final int incFullness = ii.getSpec(ItemSpecType.inc);
 
-        try (var locked = user.acquire()) {
-            // Select target pet
-            Pet target = null;
-            for (Pet pet : user.getPets()) {
-                if (target == null || target.getFullness() > pet.getFullness()) {
-                    target = pet;
-                }
+        // Select target pet
+        Pet target = null;
+        for (Pet pet : user.getPets()) {
+            if (target == null || target.getFullness() > pet.getFullness()) {
+                target = pet;
             }
-            if (target == null) {
-                log.error("Could not select target pet for using pet food item : {}", itemId);
-                user.dispose();
-                return;
-            }
-            final Optional<Integer> petIndexResult = user.getPetIndex(target.getItemSn());
-            if (petIndexResult.isEmpty()) {
-                log.error("Could not resolve pet index for item : {}", target.getItemSn());
-                user.dispose();
-                return;
-            }
-            final long petSn = target.getItemSn();
-            final int petIndex = petIndexResult.get();
-
-            // Resolve pet item
-            final InventoryManager im = user.getInventoryManager();
-            final Optional<Map.Entry<Integer, Item>> itemEntry = im.getCashInventory().getItems().entrySet().stream()
-                    .filter((entry) -> entry.getValue().getItemSn() == petSn)
-                    .findFirst();
-            if (itemEntry.isEmpty()) {
-                log.error("Could not resolve pet item : {}", target.getItemSn());
-                user.dispose();
-                return;
-            }
-            final int petPosition = itemEntry.get().getKey();
-            final Item petItem = itemEntry.get().getValue();
-
-            // Consume item
-            final Optional<InventoryOperation> consumeItemResult = consumeItem(locked, position, itemId);
-            if (consumeItemResult.isEmpty()) {
-                user.dispose();
-                return;
-            }
-            user.write(WvsContext.inventoryOperation(consumeItemResult.get(), true));
-
-            // Increase fullness
-            final PetData petData = petItem.getPetData();
-            final int fullness = petData.getFullness();
-            final boolean success = fullness < GameConstants.PET_FULLNESS_MAX;
-            petData.setFullness((byte) Math.min(fullness + incFullness, GameConstants.PET_FULLNESS_MAX));
-
-            boolean levelUp = false;
-            if (fullness <= GameConstants.PET_FULLNESS_FOR_TAMENESS) {
-                // Increase tameness (closeness)
-                final int newTameness = Math.min(petData.getTameness() + 1, GameConstants.PET_TAMENESS_MAX);
-                petData.setTameness((short) newTameness);
-
-                // Level up
-                while (petData.getLevel() < GameConstants.PET_LEVEL_MAX &&
-                        newTameness > GameConstants.getNextLevelPetCloseness(petData.getLevel())) {
-                    petData.setLevel((byte) (petData.getLevel() + 1));
-                    levelUp = true;
-                }
-            } else if (fullness == GameConstants.PET_FULLNESS_MAX) {
-                // Decrease tameness (closeness)
-                final int newTameness = Math.max(petData.getTameness() - 1, 0);
-                petData.setTameness((short) newTameness);
-            }
-
-            // Update pet item
-            final Optional<InventoryOperation> updateResult = user.getInventoryManager().updateItem(petPosition, petItem);
-            if (updateResult.isEmpty()) {
-                throw new IllegalStateException("Could not update pet item");
-            }
-
-            // Update client
-            user.write(WvsContext.inventoryOperation(updateResult.get(), false));
-            if (levelUp) {
-                user.write(UserLocal.effect(Effect.petLevelUp(petIndex)));
-                user.getField().broadcastPacket(UserRemote.effect(user, Effect.petLevelUp(petIndex)), user);
-            }
-
-            // Broadcast pet action
-            user.getField().broadcastPacket(PetPacket.petActionFeed(user, petIndex, success, false));
         }
+        if (target == null) {
+            log.error("Could not select target pet for using pet food item : {}", itemId);
+            user.dispose();
+            return;
+        }
+        final Optional<Integer> petIndexResult = user.getPetIndex(target.getItemSn());
+        if (petIndexResult.isEmpty()) {
+            log.error("Could not resolve pet index for item : {}", target.getItemSn());
+            user.dispose();
+            return;
+        }
+        final long petSn = target.getItemSn();
+        final int petIndex = petIndexResult.get();
+
+        // Resolve pet item
+        final InventoryManager im = user.getInventoryManager();
+        final Optional<Map.Entry<Integer, Item>> itemEntry = im.getCashInventory().getItems().entrySet().stream()
+                .filter((entry) -> entry.getValue().getItemSn() == petSn)
+                .findFirst();
+        if (itemEntry.isEmpty()) {
+            log.error("Could not resolve pet item : {}", target.getItemSn());
+            user.dispose();
+            return;
+        }
+        final int petPosition = itemEntry.get().getKey();
+        final Item petItem = itemEntry.get().getValue();
+
+        // Consume item
+        final Optional<InventoryOperation> consumeItemResult = consumeItem(user, position, itemId);
+        if (consumeItemResult.isEmpty()) {
+            user.dispose();
+            return;
+        }
+        user.write(WvsContext.inventoryOperation(consumeItemResult.get(), true));
+
+        // Increase fullness
+        final PetData petData = petItem.getPetData();
+        final int fullness = petData.getFullness();
+        final boolean success = fullness < GameConstants.PET_FULLNESS_MAX;
+        petData.setFullness((byte) Math.min(fullness + incFullness, GameConstants.PET_FULLNESS_MAX));
+
+        boolean levelUp = false;
+        if (fullness <= GameConstants.PET_FULLNESS_FOR_TAMENESS) {
+            // Increase tameness (closeness)
+            final int newTameness = Math.min(petData.getTameness() + 1, GameConstants.PET_TAMENESS_MAX);
+            petData.setTameness((short) newTameness);
+
+            // Level up
+            while (petData.getLevel() < GameConstants.PET_LEVEL_MAX &&
+                    newTameness > GameConstants.getNextLevelPetCloseness(petData.getLevel())) {
+                petData.setLevel((byte) (petData.getLevel() + 1));
+                levelUp = true;
+            }
+        } else if (fullness == GameConstants.PET_FULLNESS_MAX) {
+            // Decrease tameness (closeness)
+            final int newTameness = Math.max(petData.getTameness() - 1, 0);
+            petData.setTameness((short) newTameness);
+        }
+
+        // Update pet item
+        final Optional<InventoryOperation> updateResult = user.getInventoryManager().updateItem(petPosition, petItem);
+        if (updateResult.isEmpty()) {
+            throw new IllegalStateException("Could not update pet item");
+        }
+
+        // Update client
+        user.write(WvsContext.inventoryOperation(updateResult.get(), false));
+        if (levelUp) {
+            user.write(UserLocal.effect(Effect.petLevelUp(petIndex)));
+            user.getField().broadcastPacket(UserRemote.effect(user, Effect.petLevelUp(petIndex)), user);
+        }
+
+        // Broadcast pet action
+        user.getField().broadcastPacket(PetPacket.petActionFeed(user, petIndex, success, false));
     }
 
     @Handler(InHeader.UserScriptItemUseRequest)
@@ -287,14 +277,12 @@ public abstract class ItemHandler {
         final ItemInfo itemInfo = itemInfoResult.get();
 
         // Check item
-        try (var locked = user.acquire()) {
-            final InventoryManager im = locked.get().getInventoryManager();
-            final Item item = im.getInventoryByItemId(itemId).getItem(position);
-            if (item == null || item.getItemId() != itemId) {
-                log.error("Tried to use an item in position {} as item ID : {}", position, itemId);
-                user.dispose();
-                return;
-            }
+        final InventoryManager im = user.getInventoryManager();
+        final Item item = im.getInventoryByItemId(itemId).getItem(position);
+        if (item == null || item.getItemId() != itemId) {
+            log.error("Tried to use an item in position {} as item ID : {}", position, itemId);
+            user.dispose();
+            return;
         }
 
         // Dispatch item script
@@ -338,58 +326,56 @@ public abstract class ItemHandler {
             return;
         }
 
-        try (var locked = user.acquire()) {
-            // Check requirements
-            final SkillManager sm = locked.get().getSkillManager();
-            final Optional<Integer> skillIdResult = skill.stream()
-                    .filter((skillId) -> {
-                        if (reqSkillLevel > 0) {
-                            final Optional<SkillRecord> skillRecordResult = sm.getSkill(skillId);
-                            if (skillRecordResult.isEmpty()) {
-                                return false;
-                            }
-                            final SkillRecord skillRecord = skillRecordResult.get();
-                            return skillRecord.getSkillLevel() >= reqSkillLevel && skillRecord.getMasterLevel() < masterLevel;
-                        } else {
-                            final int skillRoot = SkillConstants.getSkillRoot(skillId);
-                            return JobConstants.isCorrectJobForSkillRoot(user.getJob(), skillRoot) && sm.getSkill(skillId).isEmpty();
+        // Check requirements
+        final SkillManager sm = user.getSkillManager();
+        final Optional<Integer> skillIdResult = skill.stream()
+                .filter((skillId) -> {
+                    if (reqSkillLevel > 0) {
+                        final Optional<SkillRecord> skillRecordResult = sm.getSkill(skillId);
+                        if (skillRecordResult.isEmpty()) {
+                            return false;
                         }
-                    })
-                    .findAny();
-            if (skillIdResult.isEmpty()) {
-                user.write(WvsContext.skillLearnItemResult(user.getCharacterId(), isMasteryBook, false, false, true));
-                return;
-            }
-            final int skillId = skillIdResult.get();
-
-            // Resolve skill
-            final Optional<SkillInfo> skillInfoResult = SkillProvider.getSkillInfoById(skillId);
-            if (skillInfoResult.isEmpty()) {
-                log.error("Could not resolve skill info for skill ID : {}", skillId);
-                user.write(WvsContext.skillLearnItemResult(user.getCharacterId(), isMasteryBook, false, false, true));
-                return;
-            }
-
-            // Consume item
-            final Optional<InventoryOperation> consumeItemResult = consumeItem(locked, position, itemId);
-            if (consumeItemResult.isEmpty()) {
-                user.dispose();
-                return;
-            }
-            user.write(WvsContext.inventoryOperation(consumeItemResult.get(), false));
-
-            final boolean success = Util.succeedProp(itemInfo.getInfo(ItemInfoType.success));
-            if (success) {
-                // Update skill record
-                final SkillRecord skillRecord = new SkillRecord(skillId);
-                skillRecord.setSkillLevel(user.getSkillLevel(skillId));
-                skillRecord.setMasterLevel(itemInfo.getInfo(ItemInfoType.masterLevel));
-                sm.addSkill(skillRecord);
-                user.write(WvsContext.changeSkillRecordResult(skillRecord, false));
-            }
-            user.write(WvsContext.skillLearnItemResult(user.getCharacterId(), isMasteryBook, true, success, true));
-            user.getField().broadcastPacket(WvsContext.skillLearnItemResult(user.getCharacterId(), isMasteryBook, true, success, false), user);
+                        final SkillRecord skillRecord = skillRecordResult.get();
+                        return skillRecord.getSkillLevel() >= reqSkillLevel && skillRecord.getMasterLevel() < masterLevel;
+                    } else {
+                        final int skillRoot = SkillConstants.getSkillRoot(skillId);
+                        return JobConstants.isCorrectJobForSkillRoot(user.getJob(), skillRoot) && sm.getSkill(skillId).isEmpty();
+                    }
+                })
+                .findAny();
+        if (skillIdResult.isEmpty()) {
+            user.write(WvsContext.skillLearnItemResult(user.getCharacterId(), isMasteryBook, false, false, true));
+            return;
         }
+        final int skillId = skillIdResult.get();
+
+        // Resolve skill
+        final Optional<SkillInfo> skillInfoResult = SkillProvider.getSkillInfoById(skillId);
+        if (skillInfoResult.isEmpty()) {
+            log.error("Could not resolve skill info for skill ID : {}", skillId);
+            user.write(WvsContext.skillLearnItemResult(user.getCharacterId(), isMasteryBook, false, false, true));
+            return;
+        }
+
+        // Consume item
+        final Optional<InventoryOperation> consumeItemResult = consumeItem(user, position, itemId);
+        if (consumeItemResult.isEmpty()) {
+            user.dispose();
+            return;
+        }
+        user.write(WvsContext.inventoryOperation(consumeItemResult.get(), false));
+
+        final boolean success = Util.succeedProp(itemInfo.getInfo(ItemInfoType.success));
+        if (success) {
+            // Update skill record
+            final SkillRecord skillRecord = new SkillRecord(skillId);
+            skillRecord.setSkillLevel(user.getSkillLevel(skillId));
+            skillRecord.setMasterLevel(itemInfo.getInfo(ItemInfoType.masterLevel));
+            sm.addSkill(skillRecord);
+            user.write(WvsContext.changeSkillRecordResult(skillRecord, false));
+        }
+        user.write(WvsContext.skillLearnItemResult(user.getCharacterId(), isMasteryBook, true, success, true));
+        user.getField().broadcastPacket(WvsContext.skillLearnItemResult(user.getCharacterId(), isMasteryBook, true, success, false), user);
     }
 
     @Handler(InHeader.UserPortalScrollUseRequest)
@@ -406,51 +392,49 @@ public abstract class ItemHandler {
             return;
         }
 
-        try (var locked = user.acquire()) {
-            // Check portal scroll can be used
-            final Field field = locked.get().getField();
-            if (field.hasFieldOption(FieldOption.PORTALSCROLLLIMIT)) {
-                user.write(MessagePacket.system("You can't use it here in this map."));
-                user.dispose();
-                return;
-            }
-            final int moveTo = itemInfoResult.get().getSpec(ItemSpecType.moveTo);
-            if (moveTo != GameConstants.UNDEFINED_FIELD_ID && field.isConnected(moveTo)) {
-                user.write(MessagePacket.system("You cannot go to that place."));
-                user.dispose();
-                return;
-            }
-
-            // Resolve target field
-            final int destinationFieldId = moveTo == GameConstants.UNDEFINED_FIELD_ID ? field.getReturnMap() : moveTo;
-            final Optional<Field> destinationFieldResult = user.getConnectedServer().getFieldById(destinationFieldId);
-            if (destinationFieldResult.isEmpty()) {
-                log.error("Could not resolve field ID : {}", destinationFieldId);
-                user.write(MessagePacket.system("You cannot go to that place."));
-                user.dispose();
-                return;
-            }
-            final Field destinationField = destinationFieldResult.get();
-            final Optional<PortalInfo> destinationPortalResult = destinationField.getRandomStartPoint();
-            if (destinationPortalResult.isEmpty()) {
-                log.error("Could not resolve start point portal for field ID : {}", destinationFieldId);
-                user.write(MessagePacket.system("You cannot go to that place."));
-                user.dispose();
-                return;
-            }
-
-            // Consume item
-            final Optional<InventoryOperation> consumeItemResult = consumeItem(locked, position, itemId);
-            if (consumeItemResult.isEmpty()) {
-                log.error("Failed to consume portal scroll item {} in position {}", itemId, position);
-                user.dispose();
-                return;
-            }
-            user.write(WvsContext.inventoryOperation(consumeItemResult.get(), true));
-
-            // Move to field
-            user.warp(destinationField, destinationPortalResult.get(), false, false);
+        // Check portal scroll can be used
+        final Field field = user.getField();
+        if (field.hasFieldOption(FieldOption.PORTALSCROLLLIMIT)) {
+            user.write(MessagePacket.system("You can't use it here in this map."));
+            user.dispose();
+            return;
         }
+        final int moveTo = itemInfoResult.get().getSpec(ItemSpecType.moveTo);
+        if (moveTo != GameConstants.UNDEFINED_FIELD_ID && field.isConnected(moveTo)) {
+            user.write(MessagePacket.system("You cannot go to that place."));
+            user.dispose();
+            return;
+        }
+
+        // Resolve target field
+        final int destinationFieldId = moveTo == GameConstants.UNDEFINED_FIELD_ID ? field.getReturnMap() : moveTo;
+        final Optional<Field> destinationFieldResult = user.getConnectedServer().getFieldById(destinationFieldId);
+        if (destinationFieldResult.isEmpty()) {
+            log.error("Could not resolve field ID : {}", destinationFieldId);
+            user.write(MessagePacket.system("You cannot go to that place."));
+            user.dispose();
+            return;
+        }
+        final Field destinationField = destinationFieldResult.get();
+        final Optional<PortalInfo> destinationPortalResult = destinationField.getRandomStartPoint();
+        if (destinationPortalResult.isEmpty()) {
+            log.error("Could not resolve start point portal for field ID : {}", destinationFieldId);
+            user.write(MessagePacket.system("You cannot go to that place."));
+            user.dispose();
+            return;
+        }
+
+        // Consume item
+        final Optional<InventoryOperation> consumeItemResult = consumeItem(user, position, itemId);
+        if (consumeItemResult.isEmpty()) {
+            log.error("Failed to consume portal scroll item {} in position {}", itemId, position);
+            user.dispose();
+            return;
+        }
+        user.write(WvsContext.inventoryOperation(consumeItemResult.get(), true));
+
+        // Move to field
+        user.warp(destinationField, destinationPortalResult.get(), false, false);
     }
 
     @Handler(InHeader.UserLotteryItemUseRequest)
@@ -467,47 +451,45 @@ public abstract class ItemHandler {
         }
         final ItemRewardInfo itemRewardInfo = itemRewardInfoResult.get();
 
-        try (var locked = user.acquire()) {
-            // Resolve reward
-            if (!itemRewardInfo.canAddReward(locked)) {
-                user.write(MessagePacket.system("You do not have enough inventory space."));
-                user.dispose();
-                return;
-            }
-            final Optional<ItemRewardEntry> rewardResult = Util.getRandomFromCollection(itemRewardInfo.getEntries(), ItemRewardEntry::getProbability);
-            if (rewardResult.isEmpty()) {
-                log.error("Could not resolve lottery item reward for item {}", itemId);
-                return;
-            }
-            final ItemRewardEntry rewardEntry = rewardResult.get();
-            final Optional<ItemInfo> rewardItemInfoResult = ItemProvider.getItemInfo(rewardEntry.getItemId());
-            if (rewardItemInfoResult.isEmpty()) {
-                log.error("Could not resolve item info for item ID : {}", rewardEntry.getItemId());
-                return;
-            }
+        // Resolve reward
+        if (!itemRewardInfo.canAddReward(user)) {
+            user.write(MessagePacket.system("You do not have enough inventory space."));
+            user.dispose();
+            return;
+        }
+        final Optional<ItemRewardEntry> rewardResult = Util.getRandomFromCollection(itemRewardInfo.getEntries(), ItemRewardEntry::getProbability);
+        if (rewardResult.isEmpty()) {
+            log.error("Could not resolve lottery item reward for item {}", itemId);
+            return;
+        }
+        final ItemRewardEntry rewardEntry = rewardResult.get();
+        final Optional<ItemInfo> rewardItemInfoResult = ItemProvider.getItemInfo(rewardEntry.getItemId());
+        if (rewardItemInfoResult.isEmpty()) {
+            log.error("Could not resolve item info for item ID : {}", rewardEntry.getItemId());
+            return;
+        }
 
-            // Consume item
-            final Optional<InventoryOperation> consumeItemResult = consumeItem(locked, position, itemId);
-            if (consumeItemResult.isEmpty()) {
-                log.error("Failed to consume lottery item {} in position {}", itemId, position);
-                user.dispose();
-                return;
-            }
-            user.write(WvsContext.inventoryOperation(consumeItemResult.get(), false));
+        // Consume item
+        final Optional<InventoryOperation> consumeItemResult = consumeItem(user, position, itemId);
+        if (consumeItemResult.isEmpty()) {
+            log.error("Failed to consume lottery item {} in position {}", itemId, position);
+            user.dispose();
+            return;
+        }
+        user.write(WvsContext.inventoryOperation(consumeItemResult.get(), false));
 
-            // Add reward item
-            final Item rewardItem = rewardItemInfoResult.get().createItem(user.getNextItemSn(), rewardEntry.getCount());
-            if (rewardEntry.getPeriod() > 0) {
-                rewardItem.setDateExpire(Instant.now().plus(rewardEntry.getPeriod(), ChronoUnit.MINUTES));
-            }
-            final Optional<List<InventoryOperation>> addResult = user.getInventoryManager().addItem(rewardItem);
-            if (addResult.isEmpty()) {
-                throw new IllegalStateException("Could not add reward item to inventory");
-            }
-            user.write(WvsContext.inventoryOperation(addResult.get(), true));
-            if (rewardEntry.hasEffect()) {
-                user.write(UserLocal.effect(Effect.lotteryUse(itemId, rewardEntry.getEffect())));
-            }
+        // Add reward item
+        final Item rewardItem = rewardItemInfoResult.get().createItem(user.getNextItemSn(), rewardEntry.getCount());
+        if (rewardEntry.getPeriod() > 0) {
+            rewardItem.setDateExpire(Instant.now().plus(rewardEntry.getPeriod(), ChronoUnit.MINUTES));
+        }
+        final Optional<List<InventoryOperation>> addResult = user.getInventoryManager().addItem(rewardItem);
+        if (addResult.isEmpty()) {
+            throw new IllegalStateException("Could not add reward item to inventory");
+        }
+        user.write(WvsContext.inventoryOperation(addResult.get(), true));
+        if (rewardEntry.hasEffect()) {
+            user.write(UserLocal.effect(Effect.lotteryUse(itemId, rewardEntry.getEffect())));
         }
     }
 
@@ -534,33 +516,30 @@ public abstract class ItemHandler {
             return;
         }
 
-        try (var locked = user.acquire()) {
-            // Check field limit
-            final Field field = locked.get().getField();
-            if (field.hasFieldOption(FieldOption.STATCHANGEITEMCONSUMELIMIT) && !field.getMapInfo().getAllowedItems().contains(itemId)) {
-                log.error("Tried to use stat change item by pet in a restricted field");
-                user.dispose();
-                return;
-            }
-
-            // Consume item
-            final Optional<InventoryOperation> consumeItemResult = consumeItem(locked, position, itemId);
-            if (consumeItemResult.isEmpty()) {
-                user.dispose();
-                return;
-            }
-            user.write(WvsContext.inventoryOperation(consumeItemResult.get(), true));
-
-            // Apply stat change
-            changeStat(locked, itemInfoResult.get());
+        // Check field limit
+        final Field field = user.getField();
+        if (field.hasFieldOption(FieldOption.STATCHANGEITEMCONSUMELIMIT) && !field.getMapInfo().getAllowedItems().contains(itemId)) {
+            log.error("Tried to use stat change item by pet in a restricted field");
+            user.dispose();
+            return;
         }
+
+        // Consume item
+        final Optional<InventoryOperation> consumeItemResult = consumeItem(user, position, itemId);
+        if (consumeItemResult.isEmpty()) {
+            user.dispose();
+            return;
+        }
+        user.write(WvsContext.inventoryOperation(consumeItemResult.get(), true));
+
+        // Apply stat change
+        changeStat(user, itemInfoResult.get());
     }
 
 
     // HELPER METHODS --------------------------------------------------------------------------------------------------
 
-    protected static Optional<InventoryOperation> consumeItem(Locked<User> locked, int position, int itemId) {
-        final User user = locked.get();
+    protected static Optional<InventoryOperation> consumeItem(User user, int position, int itemId) {
         final InventoryType inventoryType = InventoryType.getByItemId(itemId);
         if (inventoryType != InventoryType.CONSUME) {
             log.error("Tried to use an invalid consume item : {}", itemId);
@@ -579,8 +558,7 @@ public abstract class ItemHandler {
         return removeResult;
     }
 
-    protected static void changeStat(Locked<User> locked, ItemInfo itemInfo) {
-        final User user = locked.get();
+    protected static void changeStat(User user, ItemInfo itemInfo) {
         user.setConsumeItemEffect(itemInfo);
     }
 }

--- a/src/main/java/kinoko/handler/user/item/UpgradeItemHandler.java
+++ b/src/main/java/kinoko/handler/user/item/UpgradeItemHandler.java
@@ -26,164 +26,162 @@ public final class UpgradeItemHandler extends ItemHandler {
         final boolean whiteScroll = inPacket.decodeShort() > 1; // bWhiteScroll
         final boolean enchantSkill = inPacket.decodeBoolean(); // bEnchantSkill
 
-        try (var locked = user.acquire()) {
-            // Resolve upgrade item
-            final InventoryManager im = locked.get().getInventoryManager();
-            final Item upgradeItem = im.getInventoryByType(InventoryType.CONSUME).getItem(upgradeItemPosition);
-            if (upgradeItem == null) {
-                log.error("Received UserUpgradeItemUseRequest with upgrade item position {}", upgradeItemPosition);
-                itemUpgradeEffectError(user, enchantSkill);
-                return;
-            }
-            final Optional<ItemInfo> upgradeItemInfoResult = ItemProvider.getItemInfo(upgradeItem.getItemId());
-            if (upgradeItemInfoResult.isEmpty()) {
-                log.error("Could not resolve item info for upgrade item ID : {}", upgradeItem.getItemId());
-                itemUpgradeEffectError(user, enchantSkill);
-                return;
-            }
-            final ItemInfo upgradeItemInfo = upgradeItemInfoResult.get();
-
-            // Resolve equip item
-            final InventoryType equipInventoryType = InventoryType.getByPosition(InventoryType.EQUIP, equipItemPosition);
-            final Item equipItem = im.getInventoryByType(equipInventoryType).getItem(equipItemPosition);
-            if (equipItem == null) {
-                log.error("Received UserUpgradeItemUseRequest with equip item position {}", equipItemPosition);
-                itemUpgradeEffectError(user, enchantSkill);
-                return;
-            }
-            final boolean recoverSlotItem = upgradeItemInfo.getInfo(ItemInfoType.recover) != 0;
-            final boolean requireUpgradeCount = !recoverSlotItem && !ItemConstants.isUpgradeScrollNoConsumeWhiteScroll(upgradeItem.getItemId());
-            final EquipData equipData = equipItem.getEquipData();
-            if (equipData == null || (requireUpgradeCount && equipData.getRuc() <= 0) || !ItemConstants.isCorrectUpgradeEquip(upgradeItem.getItemId(), equipItem.getItemId())) {
-                log.error("Tried to upgrade equip item {} with upgrade item {}", equipItem.getItemId(), upgradeItem.getItemId());
-                itemUpgradeEffectError(user, enchantSkill);
-                return;
-            }
-            final Optional<ItemInfo> equipItemInfoResult = ItemProvider.getItemInfo(equipItem.getItemId());
-            if (equipItemInfoResult.isEmpty()) {
-                log.error("Could not resolve item info for equip item ID : {}", equipItem.getItemId());
-                itemUpgradeEffectError(user, enchantSkill);
-                return;
-            }
-            final ItemInfo equipItemInfo = equipItemInfoResult.get();
-            if (recoverSlotItem && equipData.getRuc() + equipData.getCuc() >= equipItemInfo.getInfo(ItemInfoType.tuc) + equipData.getIuc()) {
-                // log.error("Tried to use recover slot item {} on item {} in position {}", upgradeItem.getItemId(), equipItem.getItemId(), equipItemPosition);
-                // This is not checked by client
-                itemUpgradeEffectError(user, enchantSkill);
-                return;
-            }
-
-            // Consume white scroll and upgrade scroll
-            if (whiteScroll && requireUpgradeCount) {
-                final Optional<List<InventoryOperation>> removeWhiteScrollResult = im.removeItem(ItemConstants.WHITE_SCROLL, 1);
-                if (removeWhiteScrollResult.isEmpty()) {
-                    log.error("Failed to consume a white scroll while upgrading equip item {}", equipItem.getItemId());
-                    itemUpgradeEffectError(user, enchantSkill);
-                    return;
-                }
-                user.write(WvsContext.inventoryOperation(removeWhiteScrollResult.get(), false));
-            }
-            final Optional<InventoryOperation> removeUpgradeItemResult = im.removeItem(upgradeItemPosition, upgradeItem, 1);
-            if (removeUpgradeItemResult.isEmpty()) {
-                throw new IllegalStateException(String.format("Could not remove upgrade item %d in position %d", upgradeItem.getItemId(), upgradeItemPosition));
-            }
-            user.write(WvsContext.inventoryOperation(removeUpgradeItemResult.get(), false));
-
-            // Upgrade item
-            final boolean success = Util.succeedProp(upgradeItemInfo.getInfo(ItemInfoType.success, 100));
-            if (success) {
-                if (recoverSlotItem) {
-                    // Clean Slate Scroll
-                    equipData.setRuc((byte) (equipData.getRuc() + 1));
-                } else if (upgradeItemInfo.getInfo(ItemInfoType.preventslip) != 0) {
-                    // Scroll for Spikes on Shoes
-                    equipItem.addAttribute(ItemAttribute.EQUIP_PREVENT_SLIP);
-                    equipData.setCuc((byte) (equipData.getCuc() + 1));
-                } else if (upgradeItemInfo.getInfo(ItemInfoType.warmsupport) != 0) {
-                    // Scroll for Cape for Cold Protection
-                    equipItem.addAttribute(ItemAttribute.EQUIP_SUPPORT_WARM);
-                    equipData.setCuc((byte) (equipData.getCuc() + 1));
-                } else if (upgradeItemInfo.getInfo(ItemInfoType.randstat) != 0) {
-                    // Chaos scroll
-                    final int randMax = upgradeItemInfo.getInfo(ItemInfoType.incRandVol) != 0 ? 10 : 5; // miraculous chaos scroll
-                    final Map<ItemInfoType, Object> randStats = new EnumMap<>(ItemInfoType.class);
-                    if (equipData.getIncStr() > 0) {
-                        randStats.put(ItemInfoType.incSTR, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncDex() > 0) {
-                        randStats.put(ItemInfoType.incDEX, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncInt() > 0) {
-                        randStats.put(ItemInfoType.incINT, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncLuk() > 0) {
-                        randStats.put(ItemInfoType.incLUK, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncMaxHp() > 0) {
-                        randStats.put(ItemInfoType.incMHP, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncMaxMp() > 0) {
-                        randStats.put(ItemInfoType.incMMP, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncPad() > 0) {
-                        randStats.put(ItemInfoType.incPAD, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncMad() > 0) {
-                        randStats.put(ItemInfoType.incMAD, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncPdd() > 0) {
-                        randStats.put(ItemInfoType.incPDD, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncMdd() > 0) {
-                        randStats.put(ItemInfoType.incMDD, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncAcc() > 0) {
-                        randStats.put(ItemInfoType.incACC, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncEva() > 0) {
-                        randStats.put(ItemInfoType.incEVA, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncCraft() > 0) {
-                        randStats.put(ItemInfoType.incCraft, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncSpeed() > 0) {
-                        randStats.put(ItemInfoType.incSpeed, Util.getRandom(-randMax, randMax));
-                    }
-                    if (equipData.getIncJump() > 0) {
-                        randStats.put(ItemInfoType.incJump, Util.getRandom(-randMax, randMax));
-                    }
-                    equipData.applyScrollStats(randStats);
-                    equipData.setCuc((byte) (equipData.getCuc() + 1));
-                } else {
-                    // Normal scrolls
-                    equipData.applyScrollStats(upgradeItemInfo.getItemInfos());
-                    equipData.setCuc((byte) (equipData.getCuc() + 1));
-                }
-            } else {
-                // Check if item should be destroyed
-                final int destroyRate = upgradeItemInfo.getInfo(ItemInfoType.cursed, 0);
-                if (Util.succeedProp(destroyRate)) {
-                    final Optional<InventoryOperation> destroyItemResult = im.removeItem(equipItemPosition, equipItem);
-                    if (destroyItemResult.isEmpty()) {
-                        throw new IllegalStateException(String.format("Could not destroy equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
-                    }
-                    user.write(WvsContext.inventoryOperation(destroyItemResult.get(), true));
-                    user.getField().broadcastPacket(UserPacket.userItemUpgradeEffect(user, false, true, enchantSkill, whiteScroll && requireUpgradeCount));
-                    return;
-                }
-            }
-
-            // Decrement upgrade slot (if applicable) and update client
-            if (requireUpgradeCount && (success || !whiteScroll)) {
-                equipData.setRuc((byte) (equipData.getRuc() - 1));
-            }
-            final Optional<InventoryOperation> updateItemResult = im.updateItem(equipItemPosition, equipItem);
-            if (updateItemResult.isEmpty()) {
-                throw new IllegalStateException(String.format("Could not update equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
-            }
-            user.write(WvsContext.inventoryOperation(updateItemResult.get(), true));
-            user.getField().broadcastPacket(UserPacket.userItemUpgradeEffect(user, success, false, enchantSkill, whiteScroll && requireUpgradeCount));
+        // Resolve upgrade item
+        final InventoryManager im = user.getInventoryManager();
+        final Item upgradeItem = im.getInventoryByType(InventoryType.CONSUME).getItem(upgradeItemPosition);
+        if (upgradeItem == null) {
+            log.error("Received UserUpgradeItemUseRequest with upgrade item position {}", upgradeItemPosition);
+            itemUpgradeEffectError(user, enchantSkill);
+            return;
         }
+        final Optional<ItemInfo> upgradeItemInfoResult = ItemProvider.getItemInfo(upgradeItem.getItemId());
+        if (upgradeItemInfoResult.isEmpty()) {
+            log.error("Could not resolve item info for upgrade item ID : {}", upgradeItem.getItemId());
+            itemUpgradeEffectError(user, enchantSkill);
+            return;
+        }
+        final ItemInfo upgradeItemInfo = upgradeItemInfoResult.get();
+
+        // Resolve equip item
+        final InventoryType equipInventoryType = InventoryType.getByPosition(InventoryType.EQUIP, equipItemPosition);
+        final Item equipItem = im.getInventoryByType(equipInventoryType).getItem(equipItemPosition);
+        if (equipItem == null) {
+            log.error("Received UserUpgradeItemUseRequest with equip item position {}", equipItemPosition);
+            itemUpgradeEffectError(user, enchantSkill);
+            return;
+        }
+        final boolean recoverSlotItem = upgradeItemInfo.getInfo(ItemInfoType.recover) != 0;
+        final boolean requireUpgradeCount = !recoverSlotItem && !ItemConstants.isUpgradeScrollNoConsumeWhiteScroll(upgradeItem.getItemId());
+        final EquipData equipData = equipItem.getEquipData();
+        if (equipData == null || (requireUpgradeCount && equipData.getRuc() <= 0) || !ItemConstants.isCorrectUpgradeEquip(upgradeItem.getItemId(), equipItem.getItemId())) {
+            log.error("Tried to upgrade equip item {} with upgrade item {}", equipItem.getItemId(), upgradeItem.getItemId());
+            itemUpgradeEffectError(user, enchantSkill);
+            return;
+        }
+        final Optional<ItemInfo> equipItemInfoResult = ItemProvider.getItemInfo(equipItem.getItemId());
+        if (equipItemInfoResult.isEmpty()) {
+            log.error("Could not resolve item info for equip item ID : {}", equipItem.getItemId());
+            itemUpgradeEffectError(user, enchantSkill);
+            return;
+        }
+        final ItemInfo equipItemInfo = equipItemInfoResult.get();
+        if (recoverSlotItem && equipData.getRuc() + equipData.getCuc() >= equipItemInfo.getInfo(ItemInfoType.tuc) + equipData.getIuc()) {
+            // log.error("Tried to use recover slot item {} on item {} in position {}", upgradeItem.getItemId(), equipItem.getItemId(), equipItemPosition);
+            // This is not checked by client
+            itemUpgradeEffectError(user, enchantSkill);
+            return;
+        }
+
+        // Consume white scroll and upgrade scroll
+        if (whiteScroll && requireUpgradeCount) {
+            final Optional<List<InventoryOperation>> removeWhiteScrollResult = im.removeItem(ItemConstants.WHITE_SCROLL, 1);
+            if (removeWhiteScrollResult.isEmpty()) {
+                log.error("Failed to consume a white scroll while upgrading equip item {}", equipItem.getItemId());
+                itemUpgradeEffectError(user, enchantSkill);
+                return;
+            }
+            user.write(WvsContext.inventoryOperation(removeWhiteScrollResult.get(), false));
+        }
+        final Optional<InventoryOperation> removeUpgradeItemResult = im.removeItem(upgradeItemPosition, upgradeItem, 1);
+        if (removeUpgradeItemResult.isEmpty()) {
+            throw new IllegalStateException(String.format("Could not remove upgrade item %d in position %d", upgradeItem.getItemId(), upgradeItemPosition));
+        }
+        user.write(WvsContext.inventoryOperation(removeUpgradeItemResult.get(), false));
+
+        // Upgrade item
+        final boolean success = Util.succeedProp(upgradeItemInfo.getInfo(ItemInfoType.success, 100));
+        if (success) {
+            if (recoverSlotItem) {
+                // Clean Slate Scroll
+                equipData.setRuc((byte) (equipData.getRuc() + 1));
+            } else if (upgradeItemInfo.getInfo(ItemInfoType.preventslip) != 0) {
+                // Scroll for Spikes on Shoes
+                equipItem.addAttribute(ItemAttribute.EQUIP_PREVENT_SLIP);
+                equipData.setCuc((byte) (equipData.getCuc() + 1));
+            } else if (upgradeItemInfo.getInfo(ItemInfoType.warmsupport) != 0) {
+                // Scroll for Cape for Cold Protection
+                equipItem.addAttribute(ItemAttribute.EQUIP_SUPPORT_WARM);
+                equipData.setCuc((byte) (equipData.getCuc() + 1));
+            } else if (upgradeItemInfo.getInfo(ItemInfoType.randstat) != 0) {
+                // Chaos scroll
+                final int randMax = upgradeItemInfo.getInfo(ItemInfoType.incRandVol) != 0 ? 10 : 5; // miraculous chaos scroll
+                final Map<ItemInfoType, Object> randStats = new EnumMap<>(ItemInfoType.class);
+                if (equipData.getIncStr() > 0) {
+                    randStats.put(ItemInfoType.incSTR, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncDex() > 0) {
+                    randStats.put(ItemInfoType.incDEX, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncInt() > 0) {
+                    randStats.put(ItemInfoType.incINT, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncLuk() > 0) {
+                    randStats.put(ItemInfoType.incLUK, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncMaxHp() > 0) {
+                    randStats.put(ItemInfoType.incMHP, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncMaxMp() > 0) {
+                    randStats.put(ItemInfoType.incMMP, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncPad() > 0) {
+                    randStats.put(ItemInfoType.incPAD, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncMad() > 0) {
+                    randStats.put(ItemInfoType.incMAD, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncPdd() > 0) {
+                    randStats.put(ItemInfoType.incPDD, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncMdd() > 0) {
+                    randStats.put(ItemInfoType.incMDD, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncAcc() > 0) {
+                    randStats.put(ItemInfoType.incACC, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncEva() > 0) {
+                    randStats.put(ItemInfoType.incEVA, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncCraft() > 0) {
+                    randStats.put(ItemInfoType.incCraft, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncSpeed() > 0) {
+                    randStats.put(ItemInfoType.incSpeed, Util.getRandom(-randMax, randMax));
+                }
+                if (equipData.getIncJump() > 0) {
+                    randStats.put(ItemInfoType.incJump, Util.getRandom(-randMax, randMax));
+                }
+                equipData.applyScrollStats(randStats);
+                equipData.setCuc((byte) (equipData.getCuc() + 1));
+            } else {
+                // Normal scrolls
+                equipData.applyScrollStats(upgradeItemInfo.getItemInfos());
+                equipData.setCuc((byte) (equipData.getCuc() + 1));
+            }
+        } else {
+            // Check if item should be destroyed
+            final int destroyRate = upgradeItemInfo.getInfo(ItemInfoType.cursed, 0);
+            if (Util.succeedProp(destroyRate)) {
+                final Optional<InventoryOperation> destroyItemResult = im.removeItem(equipItemPosition, equipItem);
+                if (destroyItemResult.isEmpty()) {
+                    throw new IllegalStateException(String.format("Could not destroy equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
+                }
+                user.write(WvsContext.inventoryOperation(destroyItemResult.get(), true));
+                user.getField().broadcastPacket(UserPacket.userItemUpgradeEffect(user, false, true, enchantSkill, whiteScroll && requireUpgradeCount));
+                return;
+            }
+        }
+
+        // Decrement upgrade slot (if applicable) and update client
+        if (requireUpgradeCount && (success || !whiteScroll)) {
+            equipData.setRuc((byte) (equipData.getRuc() - 1));
+        }
+        final Optional<InventoryOperation> updateItemResult = im.updateItem(equipItemPosition, equipItem);
+        if (updateItemResult.isEmpty()) {
+            throw new IllegalStateException(String.format("Could not update equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
+        }
+        user.write(WvsContext.inventoryOperation(updateItemResult.get(), true));
+        user.getField().broadcastPacket(UserPacket.userItemUpgradeEffect(user, success, false, enchantSkill, whiteScroll && requireUpgradeCount));
     }
 
     @Handler(InHeader.UserHyperUpgradeItemUseRequest)
@@ -193,67 +191,65 @@ public final class UpgradeItemHandler extends ItemHandler {
         final int equipItemPosition = inPacket.decodeShort(); // nEPOS
         final boolean enchantSkill = inPacket.decodeBoolean(); // bEnchantSkill
 
-        try (var locked = user.acquire()) {
-            // Resolve upgrade item
-            final InventoryManager im = locked.get().getInventoryManager();
-            final Item upgradeItem = im.getInventoryByType(InventoryType.CONSUME).getItem(upgradeItemPosition);
-            if (upgradeItem == null) {
-                log.error("Received UserHyperUpgradeItemUseRequest with upgrade item position {}", upgradeItemPosition);
-                user.dispose();
-                return;
-            }
+        // Resolve upgrade item
+        final InventoryManager im = user.getInventoryManager();
+        final Item upgradeItem = im.getInventoryByType(InventoryType.CONSUME).getItem(upgradeItemPosition);
+        if (upgradeItem == null) {
+            log.error("Received UserHyperUpgradeItemUseRequest with upgrade item position {}", upgradeItemPosition);
+            user.dispose();
+            return;
+        }
 
-            // Resolve equip item
-            final InventoryType equipInventoryType = InventoryType.getByPosition(InventoryType.EQUIP, equipItemPosition);
-            final Item equipItem = im.getInventoryByType(equipInventoryType).getItem(equipItemPosition);
-            if (equipItem == null) {
-                log.error("Received UserUpgradeItemUseRequest with equip item position {}", equipItemPosition);
-                user.dispose();
-                return;
-            }
-            final Optional<ItemInfo> equipItemInfoResult = ItemProvider.getItemInfo(equipItem.getItemId());
-            if (equipItemInfoResult.isEmpty()) {
-                log.error("Could not resolve item info for equip item ID : {}", equipItem.getItemId());
-                user.dispose();
-                return;
-            }
-            final ItemInfo equipItemInfo = equipItemInfoResult.get();
-            final EquipData equipData = equipItem.getEquipData();
-            if (equipItemInfo.isCash() || equipItemInfo.getInfo(ItemInfoType.tuc) == 0 || equipData == null || equipData.getRuc() > 0 || equipData.getChuc() >= 15 ||
-                    !ItemConstants.isHyperUpgradeItem(upgradeItem.getItemId()) || !ItemConstants.isCorrectUpgradeEquip(upgradeItem.getItemId(), equipItem.getItemId())) {
-                log.error("Tried to upgrade equip item {} with item {}", equipItem.getItemId(), upgradeItem.getItemId());
-                user.dispose();
-                return;
-            }
+        // Resolve equip item
+        final InventoryType equipInventoryType = InventoryType.getByPosition(InventoryType.EQUIP, equipItemPosition);
+        final Item equipItem = im.getInventoryByType(equipInventoryType).getItem(equipItemPosition);
+        if (equipItem == null) {
+            log.error("Received UserUpgradeItemUseRequest with equip item position {}", equipItemPosition);
+            user.dispose();
+            return;
+        }
+        final Optional<ItemInfo> equipItemInfoResult = ItemProvider.getItemInfo(equipItem.getItemId());
+        if (equipItemInfoResult.isEmpty()) {
+            log.error("Could not resolve item info for equip item ID : {}", equipItem.getItemId());
+            user.dispose();
+            return;
+        }
+        final ItemInfo equipItemInfo = equipItemInfoResult.get();
+        final EquipData equipData = equipItem.getEquipData();
+        if (equipItemInfo.isCash() || equipItemInfo.getInfo(ItemInfoType.tuc) == 0 || equipData == null || equipData.getRuc() > 0 || equipData.getChuc() >= 15 ||
+                !ItemConstants.isHyperUpgradeItem(upgradeItem.getItemId()) || !ItemConstants.isCorrectUpgradeEquip(upgradeItem.getItemId(), equipItem.getItemId())) {
+            log.error("Tried to upgrade equip item {} with item {}", equipItem.getItemId(), upgradeItem.getItemId());
+            user.dispose();
+            return;
+        }
 
-            // Consume hyper upgrade scroll
-            final Optional<InventoryOperation> removeUpgradeItemResult = im.removeItem(upgradeItemPosition, upgradeItem, 1);
-            if (removeUpgradeItemResult.isEmpty()) {
-                throw new IllegalStateException(String.format("Could not remove upgrade item %d in position %d", upgradeItem.getItemId(), upgradeItemPosition));
-            }
-            user.write(WvsContext.inventoryOperation(removeUpgradeItemResult.get(), false));
+        // Consume hyper upgrade scroll
+        final Optional<InventoryOperation> removeUpgradeItemResult = im.removeItem(upgradeItemPosition, upgradeItem, 1);
+        if (removeUpgradeItemResult.isEmpty()) {
+            throw new IllegalStateException(String.format("Could not remove upgrade item %d in position %d", upgradeItem.getItemId(), upgradeItemPosition));
+        }
+        user.write(WvsContext.inventoryOperation(removeUpgradeItemResult.get(), false));
 
-            // Upgrade item
-            final boolean success = Util.succeedProp(ItemConstants.getHyperUpgradeSuccessProp(upgradeItem.getItemId(), equipData.getChuc()));
-            if (success) {
-                equipData.applyHyperUpgradeStats(equipItemInfo);
-                equipData.setChuc((byte) (equipData.getChuc() + 1));
-                // Update client
-                final Optional<InventoryOperation> updateItemResult = im.updateItem(equipItemPosition, equipItem);
-                if (updateItemResult.isEmpty()) {
-                    throw new IllegalStateException(String.format("Could not update equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
-                }
-                user.write(WvsContext.inventoryOperation(updateItemResult.get(), true));
-                user.getField().broadcastPacket(UserPacket.userItemHyperUpgradeEffect(user, true, false, enchantSkill));
-            } else {
-                // Destroy item
-                final Optional<InventoryOperation> destroyItemResult = im.removeItem(equipItemPosition, equipItem);
-                if (destroyItemResult.isEmpty()) {
-                    throw new IllegalStateException(String.format("Could not destroy equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
-                }
-                user.write(WvsContext.inventoryOperation(destroyItemResult.get(), true));
-                user.getField().broadcastPacket(UserPacket.userItemHyperUpgradeEffect(user, false, true, enchantSkill));
+        // Upgrade item
+        final boolean success = Util.succeedProp(ItemConstants.getHyperUpgradeSuccessProp(upgradeItem.getItemId(), equipData.getChuc()));
+        if (success) {
+            equipData.applyHyperUpgradeStats(equipItemInfo);
+            equipData.setChuc((byte) (equipData.getChuc() + 1));
+            // Update client
+            final Optional<InventoryOperation> updateItemResult = im.updateItem(equipItemPosition, equipItem);
+            if (updateItemResult.isEmpty()) {
+                throw new IllegalStateException(String.format("Could not update equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
             }
+            user.write(WvsContext.inventoryOperation(updateItemResult.get(), true));
+            user.getField().broadcastPacket(UserPacket.userItemHyperUpgradeEffect(user, true, false, enchantSkill));
+        } else {
+            // Destroy item
+            final Optional<InventoryOperation> destroyItemResult = im.removeItem(equipItemPosition, equipItem);
+            if (destroyItemResult.isEmpty()) {
+                throw new IllegalStateException(String.format("Could not destroy equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
+            }
+            user.write(WvsContext.inventoryOperation(destroyItemResult.get(), true));
+            user.getField().broadcastPacket(UserPacket.userItemHyperUpgradeEffect(user, false, true, enchantSkill));
         }
     }
 
@@ -264,88 +260,86 @@ public final class UpgradeItemHandler extends ItemHandler {
         final int equipItemPosition = inPacket.decodeShort(); // nEPOS
         final boolean enchantSkill = inPacket.decodeBoolean(); // bEnchantSkill
 
-        try (var locked = user.acquire()) {
-            // Resolve upgrade item
-            final InventoryManager im = locked.get().getInventoryManager();
-            final Item upgradeItem = im.getInventoryByType(InventoryType.CONSUME).getItem(upgradeItemPosition);
-            if (upgradeItem == null) {
-                log.error("Received UserItemOptionUpgradeItemUseRequest with upgrade item position {}", upgradeItemPosition);
-                user.dispose();
-                return;
-            }
+        // Resolve upgrade item
+        final InventoryManager im = user.getInventoryManager();
+        final Item upgradeItem = im.getInventoryByType(InventoryType.CONSUME).getItem(upgradeItemPosition);
+        if (upgradeItem == null) {
+            log.error("Received UserItemOptionUpgradeItemUseRequest with upgrade item position {}", upgradeItemPosition);
+            user.dispose();
+            return;
+        }
 
-            // Resolve equip item
-            final InventoryType equipInventoryType = InventoryType.getByPosition(InventoryType.EQUIP, equipItemPosition);
-            final Item equipItem = im.getInventoryByType(equipInventoryType).getItem(equipItemPosition);
-            if (equipItem == null) {
-                log.error("Received UserItemOptionUpgradeItemUseRequest with equip item position {}", equipItemPosition);
-                user.dispose();
-                return;
-            }
-            final Optional<ItemInfo> equipItemInfoResult = ItemProvider.getItemInfo(equipItem.getItemId());
-            if (equipItemInfoResult.isEmpty()) {
-                log.error("Could not resolve item info for equip item ID : {}", equipItem.getItemId());
-                user.dispose();
-                return;
-            }
-            final ItemInfo equipItemInfo = equipItemInfoResult.get();
-            final EquipData equipData = equipItem.getEquipData();
-            final Set<BodyPart> bodyParts = BodyPart.getByItemId(equipItem.getItemId());
-            if (equipItemInfo.isCash() || equipItemInfo.getInfo(ItemInfoType.tuc) == 0 || equipData == null || equipData.getGrade() != 0 ||
-                    bodyParts.stream().anyMatch(BodyPart::isDragon) || bodyParts.stream().anyMatch(BodyPart::isMechanic) ||
-                    !ItemConstants.isItemOptionUpgradeItem(upgradeItem.getItemId()) || !ItemConstants.isCorrectUpgradeEquip(upgradeItem.getItemId(), equipItem.getItemId())) {
-                log.error("Tried to upgrade equip item {} with item {}", equipItem.getItemId(), upgradeItem.getItemId());
-                user.dispose();
-                return;
-            }
+        // Resolve equip item
+        final InventoryType equipInventoryType = InventoryType.getByPosition(InventoryType.EQUIP, equipItemPosition);
+        final Item equipItem = im.getInventoryByType(equipInventoryType).getItem(equipItemPosition);
+        if (equipItem == null) {
+            log.error("Received UserItemOptionUpgradeItemUseRequest with equip item position {}", equipItemPosition);
+            user.dispose();
+            return;
+        }
+        final Optional<ItemInfo> equipItemInfoResult = ItemProvider.getItemInfo(equipItem.getItemId());
+        if (equipItemInfoResult.isEmpty()) {
+            log.error("Could not resolve item info for equip item ID : {}", equipItem.getItemId());
+            user.dispose();
+            return;
+        }
+        final ItemInfo equipItemInfo = equipItemInfoResult.get();
+        final EquipData equipData = equipItem.getEquipData();
+        final Set<BodyPart> bodyParts = BodyPart.getByItemId(equipItem.getItemId());
+        if (equipItemInfo.isCash() || equipItemInfo.getInfo(ItemInfoType.tuc) == 0 || equipData == null || equipData.getGrade() != 0 ||
+                bodyParts.stream().anyMatch(BodyPart::isDragon) || bodyParts.stream().anyMatch(BodyPart::isMechanic) ||
+                !ItemConstants.isItemOptionUpgradeItem(upgradeItem.getItemId()) || !ItemConstants.isCorrectUpgradeEquip(upgradeItem.getItemId(), equipItem.getItemId())) {
+            log.error("Tried to upgrade equip item {} with item {}", equipItem.getItemId(), upgradeItem.getItemId());
+            user.dispose();
+            return;
+        }
 
-            // Resolve item options
-            final ItemGrade itemGrade = ItemGrade.RARE;
-            final List<ItemOptionInfo> primeItemOptions = ItemProvider.getPossibleItemOptions(equipItemInfo, itemGrade);
-            final List<ItemOptionInfo> lowerItemOptions = ItemProvider.getPossibleItemOptions(equipItemInfo, itemGrade.getLowerGrade());
-            if (primeItemOptions.isEmpty() || lowerItemOptions.isEmpty()) {
-                log.error("Could not resolve item options for grade : {}", equipData.getItemGrade());
-                user.dispose();
-                return;
-            }
+        // Resolve item options
+        final ItemGrade itemGrade = ItemGrade.RARE;
+        final List<ItemOptionInfo> primeItemOptions = ItemProvider.getPossibleItemOptions(equipItemInfo, itemGrade);
+        final List<ItemOptionInfo> lowerItemOptions = ItemProvider.getPossibleItemOptions(equipItemInfo, itemGrade.getLowerGrade());
+        if (primeItemOptions.isEmpty() || lowerItemOptions.isEmpty()) {
+            log.error("Could not resolve item options for grade : {}", equipData.getItemGrade());
+            user.dispose();
+            return;
+        }
 
-            // Consume item option upgrade scroll
-            final Optional<InventoryOperation> removeUpgradeItemResult = im.removeItem(upgradeItemPosition, upgradeItem, 1);
-            if (removeUpgradeItemResult.isEmpty()) {
-                throw new IllegalStateException(String.format("Could not remove upgrade item %d in position %d", upgradeItem.getItemId(), upgradeItemPosition));
-            }
-            user.write(WvsContext.inventoryOperation(removeUpgradeItemResult.get(), false));
+        // Consume item option upgrade scroll
+        final Optional<InventoryOperation> removeUpgradeItemResult = im.removeItem(upgradeItemPosition, upgradeItem, 1);
+        if (removeUpgradeItemResult.isEmpty()) {
+            throw new IllegalStateException(String.format("Could not remove upgrade item %d in position %d", upgradeItem.getItemId(), upgradeItemPosition));
+        }
+        user.write(WvsContext.inventoryOperation(removeUpgradeItemResult.get(), false));
 
-            // Upgrade item
-            final boolean success = Util.succeedProp(ItemConstants.getItemOptionUpgradeSuccessProp(upgradeItem.getItemId()));
-            if (success) {
-                final boolean thirdLine = Util.succeedProp(ItemConstants.POTENTIAL_THIRD_LINE_PROP);
-                final boolean primeLine2 = Util.succeedProp(ItemConstants.POTENTIAL_PRIME_LINE2_PROP);
-                final boolean primeLine3 = Util.succeedProp(ItemConstants.POTENTIAL_PRIME_LINE3_PROP);
+        // Upgrade item
+        final boolean success = Util.succeedProp(ItemConstants.getItemOptionUpgradeSuccessProp(upgradeItem.getItemId()));
+        if (success) {
+            final boolean thirdLine = Util.succeedProp(ItemConstants.POTENTIAL_THIRD_LINE_PROP);
+            final boolean primeLine2 = Util.succeedProp(ItemConstants.POTENTIAL_PRIME_LINE2_PROP);
+            final boolean primeLine3 = Util.succeedProp(ItemConstants.POTENTIAL_PRIME_LINE3_PROP);
 
-                final int option1 = Util.getRandomFromCollection(primeItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0);
-                final int option2 = Util.getRandomFromCollection(primeLine2 ? primeItemOptions : lowerItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0);
-                final int option3 = thirdLine ? Util.getRandomFromCollection(primeLine3 ? primeItemOptions : lowerItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0) : 0;
-                equipData.setOption1((short) option1);
-                equipData.setOption2((short) option2);
-                equipData.setOption3((short) option3);
-                equipData.setGrade((byte) itemGrade.getValue());
-                // Update client
-                final Optional<InventoryOperation> updateItemResult = im.updateItem(equipItemPosition, equipItem);
-                if (updateItemResult.isEmpty()) {
-                    throw new IllegalStateException(String.format("Could not update equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
-                }
-                user.write(WvsContext.inventoryOperation(updateItemResult.get(), true));
-                user.getField().broadcastPacket(UserPacket.userItemOptionUpgradeEffect(user, true, false, enchantSkill));
-            } else {
-                // Destroy item
-                final Optional<InventoryOperation> destroyItemResult = im.removeItem(equipItemPosition, equipItem);
-                if (destroyItemResult.isEmpty()) {
-                    throw new IllegalStateException(String.format("Could not destroy equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
-                }
-                user.write(WvsContext.inventoryOperation(destroyItemResult.get(), true));
-                user.getField().broadcastPacket(UserPacket.userItemOptionUpgradeEffect(user, false, true, enchantSkill));
+            final int option1 = Util.getRandomFromCollection(primeItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0);
+            final int option2 = Util.getRandomFromCollection(primeLine2 ? primeItemOptions : lowerItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0);
+            final int option3 = thirdLine ? Util.getRandomFromCollection(primeLine3 ? primeItemOptions : lowerItemOptions).map(ItemOptionInfo::getItemOptionId).orElse(0) : 0;
+            equipData.setOption1((short) option1);
+            equipData.setOption2((short) option2);
+            equipData.setOption3((short) option3);
+            equipData.setGrade((byte) itemGrade.getValue());
+            // Update client
+            final Optional<InventoryOperation> updateItemResult = im.updateItem(equipItemPosition, equipItem);
+            if (updateItemResult.isEmpty()) {
+                throw new IllegalStateException(String.format("Could not update equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
             }
+            user.write(WvsContext.inventoryOperation(updateItemResult.get(), true));
+            user.getField().broadcastPacket(UserPacket.userItemOptionUpgradeEffect(user, true, false, enchantSkill));
+        } else {
+            // Destroy item
+            final Optional<InventoryOperation> destroyItemResult = im.removeItem(equipItemPosition, equipItem);
+            if (destroyItemResult.isEmpty()) {
+                throw new IllegalStateException(String.format("Could not destroy equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
+            }
+            user.write(WvsContext.inventoryOperation(destroyItemResult.get(), true));
+            user.getField().broadcastPacket(UserPacket.userItemOptionUpgradeEffect(user, false, true, enchantSkill));
         }
     }
 
@@ -355,56 +349,54 @@ public final class UpgradeItemHandler extends ItemHandler {
         final int upgradeItemPosition = inPacket.decodeShort(); // nUPOS
         final int equipItemPosition = inPacket.decodeShort(); // nEPOS
 
-        try (var locked = user.acquire()) {
-            // Resolve upgrade item
-            final InventoryManager im = locked.get().getInventoryManager();
-            final Item upgradeItem = im.getInventoryByType(InventoryType.CONSUME).getItem(upgradeItemPosition);
-            if (upgradeItem == null) {
-                log.error("Received UserItemReleaseRequest with upgrade item position {}", upgradeItemPosition);
-                user.dispose();
-                return;
-            }
-
-            // Resolve equip item
-            final InventoryType equipInventoryType = InventoryType.getByPosition(InventoryType.EQUIP, equipItemPosition);
-            final Item equipItem = im.getInventoryByType(equipInventoryType).getItem(equipItemPosition);
-            if (equipItem == null) {
-                log.error("Received UserItemReleaseRequest with equip item position {}", equipItemPosition);
-                user.dispose();
-                return;
-            }
-            final Optional<ItemInfo> equipItemInfoResult = ItemProvider.getItemInfo(equipItem.getItemId());
-            if (equipItemInfoResult.isEmpty()) {
-                log.error("Could not resolve item info for equip item ID : {}", equipItem.getItemId());
-                user.dispose();
-                return;
-            }
-            final ItemInfo equipItemInfo = equipItemInfoResult.get();
-            final EquipData equipData = equipItem.getEquipData();
-            if (equipData == null || equipData.getGrade() == 0 || equipData.isReleased() ||
-                    !ItemConstants.isReleaseItem(upgradeItem.getItemId()) ||
-                    ItemConstants.getReleaseItemLevelLimit(upgradeItem.getItemId()) < equipItemInfo.getReqLevel()) {
-                log.error("Tried to release equip item {} with item {}", equipItem.getItemId(), upgradeItem.getItemId());
-                user.dispose();
-                return;
-            }
-
-            // Consume release item
-            final Optional<InventoryOperation> removeUpgradeItemResult = im.removeItem(upgradeItemPosition, upgradeItem, 1);
-            if (removeUpgradeItemResult.isEmpty()) {
-                throw new IllegalStateException(String.format("Could not remove upgrade item %d in position %d", upgradeItem.getItemId(), upgradeItemPosition));
-            }
-            user.write(WvsContext.inventoryOperation(removeUpgradeItemResult.get(), false));
-
-            // Release item and update client
-            equipData.setGrade((byte) (equipData.getGrade() | ItemGrade.RELEASED.getValue()));
-            final Optional<InventoryOperation> updateItemResult = im.updateItem(equipItemPosition, equipItem);
-            if (updateItemResult.isEmpty()) {
-                throw new IllegalStateException(String.format("Could not update equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
-            }
-            user.write(WvsContext.inventoryOperation(updateItemResult.get(), true));
-            user.write(UserPacket.userItemReleaseEffect(user, equipItemPosition));
+        // Resolve upgrade item
+        final InventoryManager im = user.getInventoryManager();
+        final Item upgradeItem = im.getInventoryByType(InventoryType.CONSUME).getItem(upgradeItemPosition);
+        if (upgradeItem == null) {
+            log.error("Received UserItemReleaseRequest with upgrade item position {}", upgradeItemPosition);
+            user.dispose();
+            return;
         }
+
+        // Resolve equip item
+        final InventoryType equipInventoryType = InventoryType.getByPosition(InventoryType.EQUIP, equipItemPosition);
+        final Item equipItem = im.getInventoryByType(equipInventoryType).getItem(equipItemPosition);
+        if (equipItem == null) {
+            log.error("Received UserItemReleaseRequest with equip item position {}", equipItemPosition);
+            user.dispose();
+            return;
+        }
+        final Optional<ItemInfo> equipItemInfoResult = ItemProvider.getItemInfo(equipItem.getItemId());
+        if (equipItemInfoResult.isEmpty()) {
+            log.error("Could not resolve item info for equip item ID : {}", equipItem.getItemId());
+            user.dispose();
+            return;
+        }
+        final ItemInfo equipItemInfo = equipItemInfoResult.get();
+        final EquipData equipData = equipItem.getEquipData();
+        if (equipData == null || equipData.getGrade() == 0 || equipData.isReleased() ||
+                !ItemConstants.isReleaseItem(upgradeItem.getItemId()) ||
+                ItemConstants.getReleaseItemLevelLimit(upgradeItem.getItemId()) < equipItemInfo.getReqLevel()) {
+            log.error("Tried to release equip item {} with item {}", equipItem.getItemId(), upgradeItem.getItemId());
+            user.dispose();
+            return;
+        }
+
+        // Consume release item
+        final Optional<InventoryOperation> removeUpgradeItemResult = im.removeItem(upgradeItemPosition, upgradeItem, 1);
+        if (removeUpgradeItemResult.isEmpty()) {
+            throw new IllegalStateException(String.format("Could not remove upgrade item %d in position %d", upgradeItem.getItemId(), upgradeItemPosition));
+        }
+        user.write(WvsContext.inventoryOperation(removeUpgradeItemResult.get(), false));
+
+        // Release item and update client
+        equipData.setGrade((byte) (equipData.getGrade() | ItemGrade.RELEASED.getValue()));
+        final Optional<InventoryOperation> updateItemResult = im.updateItem(equipItemPosition, equipItem);
+        if (updateItemResult.isEmpty()) {
+            throw new IllegalStateException(String.format("Could not update equip item %d in position %d", equipItem.getItemId(), equipItemPosition));
+        }
+        user.write(WvsContext.inventoryOperation(updateItemResult.get(), true));
+        user.write(UserPacket.userItemReleaseEffect(user, equipItemPosition));
     }
 
     private static void itemUpgradeEffectError(User user, boolean enchantSkill) {

--- a/src/main/java/kinoko/provider/item/ItemMakeInfo.java
+++ b/src/main/java/kinoko/provider/item/ItemMakeInfo.java
@@ -3,7 +3,6 @@ package kinoko.provider.item;
 import kinoko.provider.ProviderError;
 import kinoko.provider.WzProvider;
 import kinoko.provider.wz.property.WzListProperty;
-import kinoko.util.Locked;
 import kinoko.util.Triple;
 import kinoko.util.Tuple;
 import kinoko.world.item.InventoryManager;
@@ -97,8 +96,7 @@ public final class ItemMakeInfo {
         return randomReward;
     }
 
-    public boolean canCreateItem(Locked<User> locked, boolean catalyst, List<Integer> gems) {
-        final User user = locked.get();
+    public boolean canCreateItem(User user, boolean catalyst, List<Integer> gems) {
         final InventoryManager im = user.getInventoryManager();
         final int makerSkillId = SkillConstants.getNoviceSkillAsRace(Beginner.MAKER, user.getJob());
         if (getReqSkillLevel() != 0 && user.getSkillLevel(makerSkillId) < getReqSkillLevel()) {
@@ -158,8 +156,8 @@ public final class ItemMakeInfo {
         return true;
     }
 
-    public boolean canAddReward(Locked<User> locked) {
-        final InventoryManager im = locked.get().getInventoryManager();
+    public boolean canAddReward(User user) {
+        final InventoryManager im = user.getInventoryManager();
         if (!im.canAddItem(getItemId(), 1)) {
             return false;
         }

--- a/src/main/java/kinoko/provider/item/ItemRewardInfo.java
+++ b/src/main/java/kinoko/provider/item/ItemRewardInfo.java
@@ -3,8 +3,6 @@ package kinoko.provider.item;
 import kinoko.provider.ProviderError;
 import kinoko.provider.WzProvider;
 import kinoko.provider.wz.property.WzListProperty;
-import kinoko.util.Locked;
-import kinoko.util.Triple;
 import kinoko.world.item.InventoryManager;
 import kinoko.world.user.User;
 
@@ -28,8 +26,8 @@ public final class ItemRewardInfo {
         return entries;
     }
 
-    public boolean canAddReward(Locked<User> locked) {
-        final InventoryManager im = locked.get().getInventoryManager();
+    public boolean canAddReward(User user) {
+        final InventoryManager im = user.getInventoryManager();
         for (ItemRewardEntry entry : getEntries()) {
             if (!im.canAddItem(entry.getItemId(), entry.getCount())) {
                 return false;

--- a/src/main/java/kinoko/provider/quest/act/QuestAct.java
+++ b/src/main/java/kinoko/provider/quest/act/QuestAct.java
@@ -1,10 +1,9 @@
 package kinoko.provider.quest.act;
 
-import kinoko.util.Locked;
 import kinoko.world.user.User;
 
 public interface QuestAct {
-    boolean canAct(Locked<User> locked, int rewardIndex);
+    boolean canAct(User user, int rewardIndex);
 
-    boolean doAct(Locked<User> locked, int rewardIndex);
+    boolean doAct(User user, int rewardIndex);
 }

--- a/src/main/java/kinoko/provider/quest/act/QuestBuffAct.java
+++ b/src/main/java/kinoko/provider/quest/act/QuestBuffAct.java
@@ -2,7 +2,6 @@ package kinoko.provider.quest.act;
 
 import kinoko.packet.user.QuestPacket;
 import kinoko.provider.ItemProvider;
-import kinoko.util.Locked;
 import kinoko.world.user.User;
 
 public final class QuestBuffAct implements QuestAct {
@@ -13,17 +12,17 @@ public final class QuestBuffAct implements QuestAct {
     }
 
     @Override
-    public boolean canAct(Locked<User> locked, int rewardIndex) {
+    public boolean canAct(User user, int rewardIndex) {
         if (ItemProvider.getItemInfo(buffItemId).isEmpty()) {
-            locked.get().write(QuestPacket.failedUnknown());
+            user.write(QuestPacket.failedUnknown());
             return false;
         }
         return true;
     }
 
     @Override
-    public boolean doAct(Locked<User> locked, int rewardIndex) {
-        locked.get().setConsumeItemEffect(ItemProvider.getItemInfo(buffItemId).orElseThrow());
+    public boolean doAct(User user, int rewardIndex) {
+        user.setConsumeItemEffect(ItemProvider.getItemInfo(buffItemId).orElseThrow());
         return true;
     }
 }

--- a/src/main/java/kinoko/provider/quest/act/QuestExpAct.java
+++ b/src/main/java/kinoko/provider/quest/act/QuestExpAct.java
@@ -1,7 +1,6 @@
 package kinoko.provider.quest.act;
 
 import kinoko.packet.world.MessagePacket;
-import kinoko.util.Locked;
 import kinoko.world.user.User;
 
 public final class QuestExpAct implements QuestAct {
@@ -12,13 +11,12 @@ public final class QuestExpAct implements QuestAct {
     }
 
     @Override
-    public boolean canAct(Locked<User> locked, int rewardIndex) {
+    public boolean canAct(User user, int rewardIndex) {
         return true;
     }
 
     @Override
-    public boolean doAct(Locked<User> locked, int rewardIndex) {
-        final User user = locked.get();
+    public boolean doAct(User user, int rewardIndex) {
         user.addExp(exp);
         user.write(MessagePacket.incExp(exp, 0, true, true));
         return true;

--- a/src/main/java/kinoko/provider/quest/act/QuestInfoAct.java
+++ b/src/main/java/kinoko/provider/quest/act/QuestInfoAct.java
@@ -1,6 +1,5 @@
 package kinoko.provider.quest.act;
 
-import kinoko.util.Locked;
 import kinoko.world.user.User;
 
 public final class QuestInfoAct implements QuestAct {
@@ -13,13 +12,13 @@ public final class QuestInfoAct implements QuestAct {
     }
 
     @Override
-    public boolean canAct(Locked<User> locked, int rewardIndex) {
+    public boolean canAct(User user, int rewardIndex) {
         return true;
     }
 
     @Override
-    public boolean doAct(Locked<User> locked, int rewardIndex) {
-        locked.get().getQuestManager().setQuestInfoEx(questId, info);
+    public boolean doAct(User user, int rewardIndex) {
+        user.getQuestManager().setQuestInfoEx(questId, info);
         return true;
     }
 }

--- a/src/main/java/kinoko/provider/quest/act/QuestItemAct.java
+++ b/src/main/java/kinoko/provider/quest/act/QuestItemAct.java
@@ -7,7 +7,6 @@ import kinoko.provider.ItemProvider;
 import kinoko.provider.item.ItemInfo;
 import kinoko.provider.quest.QuestItemData;
 import kinoko.provider.wz.property.WzListProperty;
-import kinoko.util.Locked;
 import kinoko.util.Util;
 import kinoko.world.item.*;
 import kinoko.world.user.User;
@@ -34,8 +33,7 @@ public final class QuestItemAct implements QuestAct {
         return choices;
     }
 
-    public void restoreLostItems(Locked<User> locked, List<Integer> lostItems) {
-        final User user = locked.get();
+    public void restoreLostItems(User user, List<Integer> lostItems) {
         final InventoryManager im = user.getInventoryManager();
         final List<QuestItemData> filteredItems = getFilteredItems(user.getGender(), user.getJob()).stream()
                 .filter(itemData -> lostItems.contains(itemData.getItemId()))
@@ -96,8 +94,7 @@ public final class QuestItemAct implements QuestAct {
         }
     }
 
-    public void removeQuestItems(Locked<User> locked) {
-        final User user = locked.get();
+    public void removeQuestItems(User user) {
         final InventoryManager im = user.getInventoryManager();
 
         // Remove quest items
@@ -121,8 +118,7 @@ public final class QuestItemAct implements QuestAct {
     }
 
     @Override
-    public boolean canAct(Locked<User> locked, int rewardIndex) {
-        final User user = locked.get();
+    public boolean canAct(User user, int rewardIndex) {
         final InventoryManager im = user.getInventoryManager();
         final List<QuestItemData> filteredItems = getFilteredItems(user.getGender(), user.getJob());
 
@@ -178,8 +174,7 @@ public final class QuestItemAct implements QuestAct {
     }
 
     @Override
-    public boolean doAct(Locked<User> locked, int rewardIndex) {
-        final User user = locked.get();
+    public boolean doAct(User user, int rewardIndex) {
         final InventoryManager im = user.getInventoryManager();
         final List<QuestItemData> filteredItems = getFilteredItems(user.getGender(), user.getJob());
 

--- a/src/main/java/kinoko/provider/quest/act/QuestMoneyAct.java
+++ b/src/main/java/kinoko/provider/quest/act/QuestMoneyAct.java
@@ -3,7 +3,6 @@ package kinoko.provider.quest.act;
 import kinoko.packet.user.QuestPacket;
 import kinoko.packet.world.MessagePacket;
 import kinoko.packet.world.WvsContext;
-import kinoko.util.Locked;
 import kinoko.world.item.InventoryManager;
 import kinoko.world.user.User;
 import kinoko.world.user.stat.Stat;
@@ -16,8 +15,7 @@ public final class QuestMoneyAct implements QuestAct {
     }
 
     @Override
-    public boolean canAct(Locked<User> locked, int rewardIndex) {
-        final User user = locked.get();
+    public boolean canAct(User user, int rewardIndex) {
         final long newMoney = ((long) user.getInventoryManager().getMoney()) + money;
         if (newMoney > Integer.MAX_VALUE || newMoney < 0) {
             user.write(QuestPacket.failedMeso());
@@ -27,8 +25,7 @@ public final class QuestMoneyAct implements QuestAct {
     }
 
     @Override
-    public boolean doAct(Locked<User> locked, int rewardIndex) {
-        final User user = locked.get();
+    public boolean doAct(User user, int rewardIndex) {
         final InventoryManager im = user.getInventoryManager();
         if (!im.addMoney(money)) {
             return false;

--- a/src/main/java/kinoko/provider/quest/act/QuestPetAct.java
+++ b/src/main/java/kinoko/provider/quest/act/QuestPetAct.java
@@ -4,7 +4,6 @@ import kinoko.packet.user.QuestPacket;
 import kinoko.packet.user.UserLocal;
 import kinoko.packet.user.UserRemote;
 import kinoko.packet.world.WvsContext;
-import kinoko.util.Locked;
 import kinoko.world.GameConstants;
 import kinoko.world.item.InventoryManager;
 import kinoko.world.item.InventoryOperation;
@@ -27,8 +26,7 @@ public final class QuestPetAct implements QuestAct {
     }
 
     @Override
-    public boolean canAct(Locked<User> locked, int rewardIndex) {
-        final User user = locked.get();
+    public boolean canAct(User user, int rewardIndex) {
         if (user.getPet(0) == null) {
             user.write(QuestPacket.failedUnknown()); // there is a clientside check, should not reach here
             return false;
@@ -37,8 +35,7 @@ public final class QuestPetAct implements QuestAct {
     }
 
     @Override
-    public boolean doAct(Locked<User> locked, int rewardIndex) {
-        final User user = locked.get();
+    public boolean doAct(User user, int rewardIndex) {
         final Pet pet = user.getPet(0); // only applied to the lead pet
         if (pet == null) {
             return false;

--- a/src/main/java/kinoko/provider/quest/act/QuestPopAct.java
+++ b/src/main/java/kinoko/provider/quest/act/QuestPopAct.java
@@ -1,7 +1,6 @@
 package kinoko.provider.quest.act;
 
 import kinoko.packet.world.MessagePacket;
-import kinoko.util.Locked;
 import kinoko.world.user.User;
 
 public final class QuestPopAct implements QuestAct {
@@ -12,13 +11,12 @@ public final class QuestPopAct implements QuestAct {
     }
 
     @Override
-    public boolean canAct(Locked<User> locked, int rewardIndex) {
+    public boolean canAct(User user, int rewardIndex) {
         return true;
     }
 
     @Override
-    public boolean doAct(Locked<User> locked, int rewardIndex) {
-        final User user = locked.get();
+    public boolean doAct(User user, int rewardIndex) {
         user.addPop(pop);
         user.write(MessagePacket.incPop(pop));
         return true;

--- a/src/main/java/kinoko/provider/quest/act/QuestSkillAct.java
+++ b/src/main/java/kinoko/provider/quest/act/QuestSkillAct.java
@@ -5,7 +5,6 @@ import kinoko.provider.SkillProvider;
 import kinoko.provider.quest.QuestSkillData;
 import kinoko.provider.skill.SkillInfo;
 import kinoko.provider.wz.property.WzListProperty;
-import kinoko.util.Locked;
 import kinoko.world.skill.SkillRecord;
 import kinoko.world.user.User;
 
@@ -21,13 +20,12 @@ public final class QuestSkillAct implements QuestAct {
     }
 
     @Override
-    public boolean canAct(Locked<User> locked, int rewardIndex) {
+    public boolean canAct(User user, int rewardIndex) {
         return true;
     }
 
     @Override
-    public boolean doAct(Locked<User> locked, int rewardIndex) {
-        final User user = locked.get();
+    public boolean doAct(User user, int rewardIndex) {
         for (QuestSkillData qsd : skills) {
             if (!qsd.getJobs().contains(user.getJob())) {
                 continue;

--- a/src/main/java/kinoko/provider/quest/act/QuestSpAct.java
+++ b/src/main/java/kinoko/provider/quest/act/QuestSpAct.java
@@ -5,7 +5,6 @@ import kinoko.packet.world.WvsContext;
 import kinoko.provider.ProviderError;
 import kinoko.provider.WzProvider;
 import kinoko.provider.wz.property.WzListProperty;
-import kinoko.util.Locked;
 import kinoko.world.job.JobConstants;
 import kinoko.world.user.User;
 import kinoko.world.user.stat.CharacterStat;
@@ -21,8 +20,7 @@ public final class QuestSpAct implements QuestAct {
     }
 
     @Override
-    public boolean canAct(Locked<User> locked, int rewardIndex) {
-        final User user = locked.get();
+    public boolean canAct(User user, int rewardIndex) {
         if (!JobConstants.getSkillRootFromJob(user.getJob()).contains(job)) {
             user.write(QuestPacket.failedUnknown());
             return false;
@@ -31,8 +29,7 @@ public final class QuestSpAct implements QuestAct {
     }
 
     @Override
-    public boolean doAct(Locked<User> locked, int rewardIndex) {
-        final User user = locked.get();
+    public boolean doAct(User user, int rewardIndex) {
         final CharacterStat cs = user.getCharacterStat();
         if (JobConstants.isExtendSpJob(cs.getJob())) {
             cs.getSp().addSp(JobConstants.getJobLevel(job), sp);

--- a/src/main/java/kinoko/provider/quest/check/QuestCheck.java
+++ b/src/main/java/kinoko/provider/quest/check/QuestCheck.java
@@ -1,8 +1,7 @@
 package kinoko.provider.quest.check;
 
-import kinoko.util.Locked;
 import kinoko.world.user.User;
 
 public interface QuestCheck {
-    boolean check(Locked<User> locked);
+    boolean check(User user);
 }

--- a/src/main/java/kinoko/provider/quest/check/QuestExCheck.java
+++ b/src/main/java/kinoko/provider/quest/check/QuestExCheck.java
@@ -3,7 +3,6 @@ package kinoko.provider.quest.check;
 import kinoko.provider.ProviderError;
 import kinoko.provider.WzProvider;
 import kinoko.provider.wz.property.WzListProperty;
-import kinoko.util.Locked;
 import kinoko.world.quest.QuestRecord;
 import kinoko.world.quest.QuestState;
 import kinoko.world.user.User;
@@ -31,8 +30,8 @@ public final class QuestExCheck implements QuestCheck {
     }
 
     @Override
-    public boolean check(Locked<User> locked) {
-        final Optional<QuestRecord> questRecordResult = locked.get().getQuestManager().getQuestRecord(getQuestId());
+    public boolean check(User user) {
+        final Optional<QuestRecord> questRecordResult = user.getQuestManager().getQuestRecord(getQuestId());
         if (questRecordResult.isEmpty()) {
             return false;
         }

--- a/src/main/java/kinoko/provider/quest/check/QuestItemCheck.java
+++ b/src/main/java/kinoko/provider/quest/check/QuestItemCheck.java
@@ -2,7 +2,6 @@ package kinoko.provider.quest.check;
 
 import kinoko.provider.quest.QuestItemData;
 import kinoko.provider.wz.property.WzListProperty;
-import kinoko.util.Locked;
 import kinoko.world.item.Inventory;
 import kinoko.world.item.InventoryManager;
 import kinoko.world.item.Item;
@@ -23,8 +22,7 @@ public final class QuestItemCheck implements QuestCheck {
     }
 
     @Override
-    public boolean check(Locked<User> locked) {
-        final User user = locked.get();
+    public boolean check(User user) {
         final InventoryManager im = user.getInventoryManager();
         final List<QuestItemData> filteredItems = getFilteredItems(user.getGender(), user.getJob());
         for (QuestItemData itemData : filteredItems) {

--- a/src/main/java/kinoko/provider/quest/check/QuestJobCheck.java
+++ b/src/main/java/kinoko/provider/quest/check/QuestJobCheck.java
@@ -2,7 +2,6 @@ package kinoko.provider.quest.check;
 
 import kinoko.provider.WzProvider;
 import kinoko.provider.wz.property.WzListProperty;
-import kinoko.util.Locked;
 import kinoko.world.user.User;
 
 import java.util.Collections;
@@ -17,8 +16,8 @@ public final class QuestJobCheck implements QuestCheck {
     }
 
     @Override
-    public boolean check(Locked<User> locked) {
-        final int jobId = locked.get().getJob();
+    public boolean check(User user) {
+        final int jobId = user.getJob();
         return jobs.contains(jobId);
     }
 

--- a/src/main/java/kinoko/provider/quest/check/QuestLevelCheck.java
+++ b/src/main/java/kinoko/provider/quest/check/QuestLevelCheck.java
@@ -1,6 +1,5 @@
 package kinoko.provider.quest.check;
 
-import kinoko.util.Locked;
 import kinoko.world.user.User;
 
 public final class QuestLevelCheck implements QuestCheck {
@@ -13,8 +12,7 @@ public final class QuestLevelCheck implements QuestCheck {
     }
 
     @Override
-    public boolean check(Locked<User> locked) {
-        final User user = locked.get();
+    public boolean check(User user) {
         if (isMinimum) {
             return user.getLevel() >= level;
         } else {

--- a/src/main/java/kinoko/provider/quest/check/QuestMobCheck.java
+++ b/src/main/java/kinoko/provider/quest/check/QuestMobCheck.java
@@ -2,7 +2,6 @@ package kinoko.provider.quest.check;
 
 import kinoko.provider.quest.QuestMobData;
 import kinoko.provider.wz.property.WzListProperty;
-import kinoko.util.Locked;
 import kinoko.world.quest.QuestManager;
 import kinoko.world.quest.QuestRecord;
 import kinoko.world.user.User;
@@ -26,8 +25,8 @@ public final class QuestMobCheck implements QuestCheck {
     }
 
     @Override
-    public boolean check(Locked<User> locked) {
-        final QuestManager qm = locked.get().getQuestManager();
+    public boolean check(User user) {
+        final QuestManager qm = user.getQuestManager();
         final Optional<QuestRecord> questRecordResult = qm.getQuestRecord(questId);
         if (questRecordResult.isEmpty()) {
             return false;

--- a/src/main/java/kinoko/script/common/ScriptDispatcher.java
+++ b/src/main/java/kinoko/script/common/ScriptDispatcher.java
@@ -93,7 +93,6 @@ public final class ScriptDispatcher {
         executor.submit(() -> {
             try {
                 log.debug("Executing {} script : {}", scriptType.name(), scriptName);
-                user.lock();
                 handler.invoke(null, scriptManager);
             } catch (Exception e) {
                 if (!(e.getCause() instanceof ScriptTermination)) {
@@ -101,7 +100,6 @@ public final class ScriptDispatcher {
                     e.printStackTrace();
                 }
             } finally {
-                user.unlock();
                 // Dispose after item scripts, and portal scripts if not warped
                 if (scriptType == ScriptType.ITEM || (scriptType == ScriptType.PORTAL && user.getFieldId() == field.getFieldId())) {
                     user.dispose();

--- a/src/main/java/kinoko/script/common/ScriptManager.java
+++ b/src/main/java/kinoko/script/common/ScriptManager.java
@@ -15,7 +15,6 @@ import kinoko.world.user.User;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 public interface ScriptManager {
     // USER METHODS ----------------------------------------------------------------------------------------------------
@@ -185,8 +184,6 @@ public interface ScriptManager {
 
 
     // EVENT METHODS ---------------------------------------------------------------------------------------------------
-
-    void sleep(long delay, TimeUnit timeUnit);
 
     boolean checkParty(int memberCount, int levelMin);
 

--- a/src/main/java/kinoko/script/common/ScriptManagerImpl.java
+++ b/src/main/java/kinoko/script/common/ScriptManagerImpl.java
@@ -23,6 +23,7 @@ import kinoko.server.event.EventState;
 import kinoko.server.event.EventType;
 import kinoko.server.field.Instance;
 import kinoko.server.field.InstanceFieldStorage;
+import kinoko.server.node.ServerExecutor;
 import kinoko.server.packet.OutPacket;
 import kinoko.util.Rect;
 import kinoko.util.Tuple;
@@ -1077,10 +1078,13 @@ public final class ScriptManagerImpl implements ScriptManager {
     }
 
     private ScriptAnswer handleAnswer() {
-        // Unlock user while waiting on answer
+        // Unlock while waiting on answer
+        ServerExecutor.unlockExecutor(field);
         answerFuture = new CompletableFuture<>();
         final ScriptAnswer answer = answerFuture.join();
         answerFuture = null;
+        // Lock again after join
+        ServerExecutor.lockExecutor(field);
         user.setDialog(null);
         // Handle answer
         if (answer.getAction() == -1 || answer.getAction() == 5) {

--- a/src/main/java/kinoko/script/common/ScriptManagerImpl.java
+++ b/src/main/java/kinoko/script/common/ScriptManagerImpl.java
@@ -41,7 +41,6 @@ import kinoko.world.job.Job;
 import kinoko.world.job.JobConstants;
 import kinoko.world.quest.QuestRecord;
 import kinoko.world.quest.QuestRecordType;
-import kinoko.world.skill.SkillConstants;
 import kinoko.world.skill.SkillManager;
 import kinoko.world.skill.SkillRecord;
 import kinoko.world.user.Dragon;
@@ -53,7 +52,6 @@ import kinoko.world.user.stat.StatConstants;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public final class ScriptManagerImpl implements ScriptManager {
@@ -643,9 +641,7 @@ public final class ScriptManagerImpl implements ScriptManager {
         final PortalInfo targetPortal = portalResult.get();
         // Warp user and party members in field
         field.getUserPool().forEachPartyMember(user, (member) -> {
-            try (var lockedMember = member.acquire()) {
-                member.warp(targetField, targetPortal, false, false);
-            }
+            member.warp(targetField, targetPortal, false, false);
         });
         user.warp(targetField, targetPortal, false, false);
     }
@@ -687,9 +683,7 @@ public final class ScriptManagerImpl implements ScriptManager {
         final PortalInfo targetPortal = portalResult.get();
         // Warp user and party members in field
         field.getUserPool().forEachPartyMember(user, (member) -> {
-            try (var lockedMember = member.acquire()) {
-                member.warp(targetField, targetPortal, false, false);
-            }
+            member.warp(targetField, targetPortal, false, false);
         });
         user.warp(targetField, targetPortal, false, false);
     }
@@ -811,28 +805,14 @@ public final class ScriptManagerImpl implements ScriptManager {
     public void setReactorState(int templateId, int newState) {
         field.getReactorPool().forEach((reactor) -> {
             if (reactor.getTemplateId() == templateId) {
-                try (var lockedReactor = reactor.acquire()) {
-                    reactor.setState(newState);
-                    field.broadcastPacket(FieldPacket.reactorChangeState(reactor, 0, 0, 0));
-                }
+                reactor.setState(newState);
+                field.broadcastPacket(FieldPacket.reactorChangeState(reactor, 0, 0, 0));
             }
         });
     }
 
 
     // EVENT METHODS ---------------------------------------------------------------------------------------------------
-
-    @Override
-    public void sleep(long delay, TimeUnit timeUnit) {
-        user.unlock();
-        try {
-            timeUnit.sleep(delay); // Thread.sleep
-        } catch (InterruptedException e) {
-            throw new ScriptError("Interrupted during sleep");
-        } finally {
-            user.lock(); // executes before ScriptError propagates to ScriptDispatcher
-        }
-    }
 
     @Override
     public boolean checkParty(int memberCount, int levelMin) {
@@ -904,9 +884,7 @@ public final class ScriptManagerImpl implements ScriptManager {
         addExp(exp);
         field.getUserPool().forEach((member) -> {
             if (member.getCharacterId() != user.getCharacterId()) {
-                try (var lockedMember = member.acquire()) {
-                    member.addExp(exp);
-                }
+                member.addExp(exp);
             }
         });
     }
@@ -1100,11 +1078,9 @@ public final class ScriptManagerImpl implements ScriptManager {
 
     private ScriptAnswer handleAnswer() {
         // Unlock user while waiting on answer
-        user.unlock();
         answerFuture = new CompletableFuture<>();
         final ScriptAnswer answer = answerFuture.join();
         answerFuture = null;
-        user.lock();
         user.setDialog(null);
         // Handle answer
         if (answer.getAction() == -1 || answer.getAction() == 5) {

--- a/src/main/java/kinoko/script/continent/GoldenTemple.java
+++ b/src/main/java/kinoko/script/continent/GoldenTemple.java
@@ -3,10 +3,8 @@ package kinoko.script.continent;
 import kinoko.script.common.Script;
 import kinoko.script.common.ScriptHandler;
 import kinoko.script.common.ScriptManager;
-import kinoko.world.field.Field;
 
 import java.util.Map;
-import java.util.Optional;
 
 public final class GoldenTemple extends ScriptHandler {
     public static final int GOLDEN_TICKET_ID = 4001431;

--- a/src/main/java/kinoko/server/dialog/miniroom/EntrustedShop.java
+++ b/src/main/java/kinoko/server/dialog/miniroom/EntrustedShop.java
@@ -1,7 +1,6 @@
 package kinoko.server.dialog.miniroom;
 
 import kinoko.server.packet.InPacket;
-import kinoko.util.Locked;
 import kinoko.world.user.User;
 
 public final class EntrustedShop extends MiniRoom {
@@ -44,12 +43,12 @@ public final class EntrustedShop extends MiniRoom {
     }
 
     @Override
-    public void handlePacket(Locked<User> locked, MiniRoomProtocol mrp, InPacket inPacket) {
+    public void handlePacket(User user, MiniRoomProtocol mrp, InPacket inPacket) {
 
     }
 
     @Override
-    public void leaveUnsafe(User user) {
+    public void leave(User user) {
 
     }
 

--- a/src/main/java/kinoko/server/dialog/miniroom/MemoryGameRoom.java
+++ b/src/main/java/kinoko/server/dialog/miniroom/MemoryGameRoom.java
@@ -2,7 +2,6 @@ package kinoko.server.dialog.miniroom;
 
 import kinoko.packet.field.MiniRoomPacket;
 import kinoko.server.packet.InPacket;
-import kinoko.util.Locked;
 import kinoko.world.user.User;
 
 public final class MemoryGameRoom extends MiniGameRoom {
@@ -24,8 +23,7 @@ public final class MemoryGameRoom extends MiniGameRoom {
     }
 
     @Override
-    public void handlePacket(Locked<User> locked, MiniRoomProtocol mrp, InPacket inPacket) {
-        final User user = locked.get();
+    public void handlePacket(User user, MiniRoomProtocol mrp, InPacket inPacket) {
         final User other = getOther(user);
         if (other == null) {
             log.error("Received mini room action {} without another player in the memory game room", mrp);
@@ -69,7 +67,7 @@ public final class MemoryGameRoom extends MiniGameRoom {
                 }
             }
             default -> {
-                super.handlePacket(locked, mrp, inPacket);
+                super.handlePacket(user, mrp, inPacket);
             }
         }
     }

--- a/src/main/java/kinoko/server/dialog/miniroom/MiniRoom.java
+++ b/src/main/java/kinoko/server/dialog/miniroom/MiniRoom.java
@@ -3,8 +3,6 @@ package kinoko.server.dialog.miniroom;
 import kinoko.server.dialog.Dialog;
 import kinoko.server.packet.InPacket;
 import kinoko.server.packet.OutPacket;
-import kinoko.util.Lockable;
-import kinoko.util.Locked;
 import kinoko.world.field.FieldObjectImpl;
 import kinoko.world.user.User;
 import org.apache.logging.log4j.LogManager;
@@ -13,12 +11,9 @@ import org.apache.logging.log4j.Logger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
-public abstract class MiniRoom extends FieldObjectImpl implements Dialog, Lockable<MiniRoom> {
+public abstract class MiniRoom extends FieldObjectImpl implements Dialog {
     protected static final Logger log = LogManager.getLogger(MiniRoom.class);
-    private final Lock lock = new ReentrantLock();
     private final String title;
     private final String password;
     private final int gameSpec;
@@ -38,9 +33,9 @@ public abstract class MiniRoom extends FieldObjectImpl implements Dialog, Lockab
 
     public abstract int getMaxUsers();
 
-    public abstract void handlePacket(Locked<User> locked, MiniRoomProtocol mrp, InPacket inPacket);
+    public abstract void handlePacket(User user, MiniRoomProtocol mrp, InPacket inPacket);
 
-    public abstract void leaveUnsafe(User user);
+    public abstract void leave(User user);
 
     public abstract void updateBalloon();
 
@@ -132,15 +127,5 @@ public abstract class MiniRoom extends FieldObjectImpl implements Dialog, Lockab
         for (var entry : users.entrySet()) {
             entry.getValue().write(outPacket);
         }
-    }
-
-    @Override
-    public void lock() {
-        lock.lock();
-    }
-
-    @Override
-    public void unlock() {
-        lock.unlock();
     }
 }

--- a/src/main/java/kinoko/server/dialog/miniroom/OmokRoom.java
+++ b/src/main/java/kinoko/server/dialog/miniroom/OmokRoom.java
@@ -2,7 +2,6 @@ package kinoko.server.dialog.miniroom;
 
 import kinoko.packet.field.MiniRoomPacket;
 import kinoko.server.packet.InPacket;
-import kinoko.util.Locked;
 import kinoko.world.user.User;
 
 public final class OmokRoom extends MiniGameRoom {
@@ -23,8 +22,7 @@ public final class OmokRoom extends MiniGameRoom {
     }
 
     @Override
-    public void handlePacket(Locked<User> locked, MiniRoomProtocol mrp, InPacket inPacket) {
-        final User user = locked.get();
+    public void handlePacket(User user, MiniRoomProtocol mrp, InPacket inPacket) {
         final User other = getOther(user);
         if (other == null) {
             log.error("Received mini room action {} without another player in the omok game room", mrp);
@@ -84,7 +82,7 @@ public final class OmokRoom extends MiniGameRoom {
                 }
             }
             default -> {
-                super.handlePacket(locked, mrp, inPacket);
+                super.handlePacket(user, mrp, inPacket);
             }
         }
     }

--- a/src/main/java/kinoko/server/dialog/shop/ShopDialog.java
+++ b/src/main/java/kinoko/server/dialog/shop/ShopDialog.java
@@ -10,7 +10,6 @@ import kinoko.provider.skill.SkillStat;
 import kinoko.server.dialog.Dialog;
 import kinoko.server.packet.InPacket;
 import kinoko.server.packet.OutPacket;
-import kinoko.util.Locked;
 import kinoko.world.GameConstants;
 import kinoko.world.item.*;
 import kinoko.world.job.cygnus.NightWalker;
@@ -34,8 +33,7 @@ public final class ShopDialog implements Dialog {
         this.items = items;
     }
 
-    public void handlePacket(Locked<User> locked, InPacket inPacket) {
-        final User user = locked.get();
+    public void handlePacket(User user, InPacket inPacket) {
         final int type = inPacket.decodeByte();
         final ShopRequestType requestType = ShopRequestType.getByValue(type);
         if (requestType == null) {

--- a/src/main/java/kinoko/server/dialog/trunk/TrunkDialog.java
+++ b/src/main/java/kinoko/server/dialog/trunk/TrunkDialog.java
@@ -5,7 +5,6 @@ import kinoko.packet.world.WvsContext;
 import kinoko.provider.npc.NpcTemplate;
 import kinoko.server.dialog.Dialog;
 import kinoko.server.packet.InPacket;
-import kinoko.util.Locked;
 import kinoko.world.item.*;
 import kinoko.world.user.User;
 import kinoko.world.user.stat.Stat;
@@ -32,159 +31,155 @@ public final class TrunkDialog implements Dialog {
         return npcTemplate.getTrunkGet();
     }
 
-    public void handlePacket(Locked<User> locked, InPacket inPacket) {
-        final User user = locked.get();
+    public void handlePacket(User user, InPacket inPacket) {
         final int type = inPacket.decodeByte();
         final TrunkRequestType requestType = TrunkRequestType.getByValue(type);
         if (requestType == null) {
             log.error("Unknown trunk request type {}", type);
             return;
         }
-        // Lock account to access trunk
-        try (var lockedAccount = user.getAccount().acquire()) {
-            final Trunk trunk = lockedAccount.get().getTrunk();
-            switch (requestType) {
-                case GetItem -> {
-                    final InventoryType inventoryType = InventoryType.getByValue(inPacket.decodeByte());
-                    final int position = inPacket.decodeByte(); // CTrunkDlg::ITEM->nIdx
-                    if (inventoryType == null || inventoryType == InventoryType.EQUIPPED) {
-                        user.write(TrunkPacket.of(TrunkResultType.GetUnknown));
-                        return;
+        final Trunk trunk = user.getAccount().getTrunk();
+        switch (requestType) {
+            case GetItem -> {
+                final InventoryType inventoryType = InventoryType.getByValue(inPacket.decodeByte());
+                final int position = inPacket.decodeByte(); // CTrunkDlg::ITEM->nIdx
+                if (inventoryType == null || inventoryType == InventoryType.EQUIPPED) {
+                    user.write(TrunkPacket.of(TrunkResultType.GetUnknown));
+                    return;
+                }
+                // Check if user has enough money
+                final InventoryManager im = user.getInventoryManager();
+                if (im.getMoney() < getTrunkGet()) {
+                    user.write(TrunkPacket.of(TrunkResultType.GetNoMoney));
+                    return;
+                }
+                // Check if user can move item from trunk to inventory
+                final Item item = trunk.getItem(inventoryType, position);
+                if (item == null) {
+                    user.write(TrunkPacket.serverMsg("Due to an error, the trade did not happen."));
+                    return;
+                }
+                if (!im.canAddItem(item)) {
+                    user.write(TrunkPacket.of(TrunkResultType.GetUnknown));
+                    return;
+                }
+                // Deduct money and move item
+                if (!im.addMoney(-getTrunkGet())) {
+                    throw new IllegalStateException("Could not deduct trunk get fee");
+                }
+                if (!trunk.getItems().remove(item)) {
+                    throw new IllegalStateException("Could not remove item from trunk");
+                }
+                final Optional<List<InventoryOperation>> addItemResult = im.addItem(item);
+                if (addItemResult.isEmpty()) {
+                    throw new IllegalStateException("Could not add trunk item into inventory");
+                }
+                // Update client
+                user.write(TrunkPacket.getSuccess(trunk));
+                user.write(WvsContext.inventoryOperation(addItemResult.get(), false));
+                user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
+            }
+            case PutItem -> {
+                final int position = inPacket.decodeShort(); // nPOS
+                final int itemId = inPacket.decodeInt(); // nItemID
+                final int quantity = inPacket.decodeShort(); // nCount
+                // Check if user has money and item
+                final InventoryManager im = user.getInventoryManager();
+                if (im.getMoney() < getTrunkPut()) {
+                    user.write(TrunkPacket.of(TrunkResultType.PutNoMoney));
+                    return;
+                }
+                final InventoryType inventoryType = InventoryType.getByItemId(itemId);
+                final Item item = im.getInventoryByType(inventoryType).getItem(position);
+                if (item == null || item.getItemId() != itemId || item.getQuantity() < quantity) {
+                    user.write(TrunkPacket.serverMsg("Due to an error, the trade did not happen."));
+                    return;
+                }
+                // Check if trunk has space for item
+                if (trunk.getRemaining() == 0) {
+                    user.write(TrunkPacket.of(TrunkResultType.PutNoSpace));
+                    return;
+                }
+                // Deduct money and move item
+                if (!im.addMoney(-getTrunkPut())) {
+                    throw new IllegalStateException("Could not deduct trunk put fee");
+                }
+                if (item.getItemType() == ItemType.BUNDLE && !ItemConstants.isRechargeableItem(item.getItemId()) && item.getQuantity() > quantity) {
+                    // Update item count
+                    item.setQuantity((short) (item.getQuantity() - quantity));
+                    user.write(WvsContext.inventoryOperation(InventoryOperation.itemNumber(inventoryType, position, item.getQuantity()), false));
+                    // Create partial item
+                    final Item partialItem = new Item(item);
+                    partialItem.setItemSn(user.getNextItemSn());
+                    partialItem.setQuantity((short) quantity);
+                    partialItem.setPossibleTrading(false);
+                    trunk.getItems().add(partialItem);
+                } else {
+                    // Move full item
+                    final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item);
+                    if (removeItemResult.isEmpty()) {
+                        throw new IllegalStateException("Could not remove item from inventory");
                     }
-                    // Check if user has enough money
-                    final InventoryManager im = user.getInventoryManager();
-                    if (im.getMoney() < getTrunkGet()) {
+                    item.setPossibleTrading(false);
+                    trunk.getItems().add(item);
+                    user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
+                }
+                // Update client
+                user.write(TrunkPacket.putSuccess(trunk));
+                user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
+            }
+            case SortItem -> {
+                // Sort items by item id (ascending), then quantity (descending)
+                trunk.getItems().sort(Comparator.comparing(Item::getItemId).thenComparing(Item::getQuantity, Comparator.reverseOrder()));
+                user.write(TrunkPacket.sortItem(trunk));
+            }
+            case Money -> {
+                final int money = inPacket.decodeInt(); // nMoney
+                final InventoryManager im = user.getInventoryManager();
+                if (money > 0) {
+                    // CTrunkDlg::SendGetMoneyRequest
+                    // Check if money can be moved from trunk to inventory
+                    if (!trunk.canAddMoney(-money)) {
                         user.write(TrunkPacket.of(TrunkResultType.GetNoMoney));
                         return;
                     }
-                    // Check if user can move item from trunk to inventory
-                    final Item item = trunk.getItem(inventoryType, position);
-                    if (item == null) {
-                        user.write(TrunkPacket.serverMsg("Due to an error, the trade did not happen."));
+                    if (!im.canAddMoney(money)) {
+                        user.write(TrunkPacket.serverMsg("You cannot hold any more mesos."));
                         return;
                     }
-                    if (!im.canAddItem(item)) {
-                        user.write(TrunkPacket.of(TrunkResultType.GetUnknown));
-                        return;
+                    // Move money
+                    if (!trunk.addMoney(-money)) {
+                        throw new IllegalStateException("Could not take money from trunk");
                     }
-                    // Deduct money and move item
-                    if (!im.addMoney(-getTrunkGet())) {
-                        throw new IllegalStateException("Could not deduct trunk get fee");
+                    if (!im.addMoney(money)) {
+                        throw new IllegalStateException("Could not add money to inventory");
                     }
-                    if (!trunk.getItems().remove(item)) {
-                        throw new IllegalStateException("Could not remove item from trunk");
-                    }
-                    final Optional<List<InventoryOperation>> addItemResult = im.addItem(item);
-                    if (addItemResult.isEmpty()) {
-                        throw new IllegalStateException("Could not add trunk item into inventory");
-                    }
-                    // Update client
-                    user.write(TrunkPacket.getSuccess(trunk));
-                    user.write(WvsContext.inventoryOperation(addItemResult.get(), false));
+                    user.write(TrunkPacket.moneySuccess(trunk));
                     user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
-                }
-                case PutItem -> {
-                    final int position = inPacket.decodeShort(); // nPOS
-                    final int itemId = inPacket.decodeInt(); // nItemID
-                    final int quantity = inPacket.decodeShort(); // nCount
-                    // Check if user has money and item
-                    final InventoryManager im = user.getInventoryManager();
-                    if (im.getMoney() < getTrunkPut()) {
+                } else if (money < 0) {
+                    // CTrunkDlg::SendPutMoneyRequest
+                    // Check if money can be moved from inventory to trunk
+                    if (!im.canAddMoney(money)) {
                         user.write(TrunkPacket.of(TrunkResultType.PutNoMoney));
                         return;
                     }
-                    final InventoryType inventoryType = InventoryType.getByItemId(itemId);
-                    final Item item = im.getInventoryByType(inventoryType).getItem(position);
-                    if (item == null || item.getItemId() != itemId || item.getQuantity() < quantity) {
-                        user.write(TrunkPacket.serverMsg("Due to an error, the trade did not happen."));
-                        return;
-                    }
-                    // Check if trunk has space for item
-                    if (trunk.getRemaining() == 0) {
+                    if (!trunk.canAddMoney(-money)) {
                         user.write(TrunkPacket.of(TrunkResultType.PutNoSpace));
                         return;
                     }
-                    // Deduct money and move item
-                    if (!im.addMoney(-getTrunkPut())) {
-                        throw new IllegalStateException("Could not deduct trunk put fee");
+                    // Move money
+                    if (!im.addMoney(money)) {
+                        throw new IllegalStateException("Could not take money from inventory");
                     }
-                    if (item.getItemType() == ItemType.BUNDLE && !ItemConstants.isRechargeableItem(item.getItemId()) && item.getQuantity() > quantity) {
-                        // Update item count
-                        item.setQuantity((short) (item.getQuantity() - quantity));
-                        user.write(WvsContext.inventoryOperation(InventoryOperation.itemNumber(inventoryType, position, item.getQuantity()), false));
-                        // Create partial item
-                        final Item partialItem = new Item(item);
-                        partialItem.setItemSn(user.getNextItemSn());
-                        partialItem.setQuantity((short) quantity);
-                        partialItem.setPossibleTrading(false);
-                        trunk.getItems().add(partialItem);
-                    } else {
-                        // Move full item
-                        final Optional<InventoryOperation> removeItemResult = im.removeItem(position, item);
-                        if (removeItemResult.isEmpty()) {
-                            throw new IllegalStateException("Could not remove item from inventory");
-                        }
-                        item.setPossibleTrading(false);
-                        trunk.getItems().add(item);
-                        user.write(WvsContext.inventoryOperation(removeItemResult.get(), false));
+                    if (!trunk.addMoney(-money)) {
+                        throw new IllegalStateException("Could not add money to trunk");
                     }
-                    // Update client
-                    user.write(TrunkPacket.putSuccess(trunk));
+                    user.write(TrunkPacket.moneySuccess(trunk));
                     user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
                 }
-                case SortItem -> {
-                    // Sort items by item id (ascending), then quantity (descending)
-                    trunk.getItems().sort(Comparator.comparing(Item::getItemId).thenComparing(Item::getQuantity, Comparator.reverseOrder()));
-                    user.write(TrunkPacket.sortItem(trunk));
-                }
-                case Money -> {
-                    final int money = inPacket.decodeInt(); // nMoney
-                    final InventoryManager im = user.getInventoryManager();
-                    if (money > 0) {
-                        // CTrunkDlg::SendGetMoneyRequest
-                        // Check if money can be moved from trunk to inventory
-                        if (!trunk.canAddMoney(-money)) {
-                            user.write(TrunkPacket.of(TrunkResultType.GetNoMoney));
-                            return;
-                        }
-                        if (!im.canAddMoney(money)) {
-                            user.write(TrunkPacket.serverMsg("You cannot hold any more mesos."));
-                            return;
-                        }
-                        // Move money
-                        if (!trunk.addMoney(-money)) {
-                            throw new IllegalStateException("Could not take money from trunk");
-                        }
-                        if (!im.addMoney(money)) {
-                            throw new IllegalStateException("Could not add money to inventory");
-                        }
-                        user.write(TrunkPacket.moneySuccess(trunk));
-                        user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
-                    } else if (money < 0) {
-                        // CTrunkDlg::SendPutMoneyRequest
-                        // Check if money can be moved from inventory to trunk
-                        if (!im.canAddMoney(money)) {
-                            user.write(TrunkPacket.of(TrunkResultType.PutNoMoney));
-                            return;
-                        }
-                        if (!trunk.canAddMoney(-money)) {
-                            user.write(TrunkPacket.of(TrunkResultType.PutNoSpace));
-                            return;
-                        }
-                        // Move money
-                        if (!im.addMoney(money)) {
-                            throw new IllegalStateException("Could not take money from inventory");
-                        }
-                        if (!trunk.addMoney(-money)) {
-                            throw new IllegalStateException("Could not add money to trunk");
-                        }
-                        user.write(TrunkPacket.moneySuccess(trunk));
-                        user.write(WvsContext.statChanged(Stat.MONEY, im.getMoney(), true));
-                    }
-                }
-                case CloseDialog -> {
-                    user.setDialog(null);
-                }
+            }
+            case CloseDialog -> {
+                user.setDialog(null);
             }
         }
     }

--- a/src/main/java/kinoko/server/event/Event.java
+++ b/src/main/java/kinoko/server/event/Event.java
@@ -68,9 +68,7 @@ public abstract class Event {
             return;
         }
         sourceFieldResult.get().getUserPool().forEach((user) -> {
-            try (var locked = user.acquire()) {
-                locked.get().warp(destinationField, destinationPortal, false, false);
-            }
+            user.warp(destinationField, destinationPortal, false, false);
         });
     }
 
@@ -103,10 +101,8 @@ public abstract class Event {
         // Resolve and change reactor state
         field.getReactorPool().forEach((reactor) -> {
             if (reactor.getTemplateId() == reactorTemplateId) {
-                try (var lockedReactor = reactor.acquire()) {
-                    reactor.setState(newState);
-                    field.broadcastPacket(FieldPacket.reactorChangeState(reactor, 0, 0, 0));
-                }
+                reactor.setState(newState);
+                field.broadcastPacket(FieldPacket.reactorChangeState(reactor, 0, 0, 0));
             }
         });
     }

--- a/src/main/java/kinoko/server/field/Instance.java
+++ b/src/main/java/kinoko/server/field/Instance.java
@@ -14,8 +14,8 @@ import java.util.stream.Collectors;
 public final class Instance {
     private final int instanceId;
     private final int returnMap;
-    private final Map<Integer, User> userMap;
-    private final Map<String, String> variables;
+    private final ConcurrentHashMap<Integer, User> userMap;
+    private final ConcurrentHashMap<String, String> variables;
     private final ChannelServerNode channelServerNode;
     private final Instant expireTime;
 

--- a/src/main/java/kinoko/server/field/Instance.java
+++ b/src/main/java/kinoko/server/field/Instance.java
@@ -2,7 +2,6 @@ package kinoko.server.field;
 
 import kinoko.packet.field.FieldPacket;
 import kinoko.server.node.ChannelServerNode;
-import kinoko.util.Lockable;
 import kinoko.world.user.User;
 
 import java.time.Instant;
@@ -10,12 +9,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
-public final class Instance implements Lockable<Instance> {
-    private final Lock lock = new ReentrantLock();
+public final class Instance {
     private final int instanceId;
     private final int returnMap;
     private final Map<Integer, User> userMap;
@@ -79,15 +75,5 @@ public final class Instance implements Lockable<Instance> {
 
     public void setVariable(String key, String value) {
         variables.put(key, value);
-    }
-
-    @Override
-    public void lock() {
-        lock.lock();
-    }
-
-    @Override
-    public void unlock() {
-        lock.unlock();
     }
 }

--- a/src/main/java/kinoko/server/netty/PacketDecoder.java
+++ b/src/main/java/kinoko/server/netty/PacketDecoder.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import kinoko.server.ServerConstants;
+import kinoko.server.node.Client;
 import kinoko.server.node.ServerExecutor;
 import kinoko.server.packet.InPacket;
 import kinoko.server.packet.NioBufferInPacket;
@@ -21,12 +22,12 @@ public final class PacketDecoder extends ByteToMessageDecoder {
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
-        final NettyClient c = ctx.channel().attr(NettyClient.CLIENT_KEY).get();
-        if (c == null) {
+        final Client client = (Client) ctx.channel().attr(NettyClient.CLIENT_KEY).get();
+        if (client == null) {
             return;
         }
-        final byte[] iv = c.getRecvIv();
-        if (c.getStoredLength() < 0) {
+        final byte[] iv = client.getRecvIv();
+        if (client.getStoredLength() < 0) {
             if (in.readableBytes() < 4) {
                 return;
             }
@@ -36,19 +37,19 @@ public final class PacketDecoder extends ByteToMessageDecoder {
             final int version = ((header[0] ^ iv[2]) & 0xFF) | (((header[1] ^ iv[3]) << 8) & 0xFF00);
             if (version != RECV_VERSION) {
                 log.warn("Incorrect packet seq, dropping client");
-                ServerExecutor.submitService(c::close);
+                ServerExecutor.submit(client, client::close);
                 return;
             }
             final int length = ((header[0] ^ header[2]) & 0xFF) | (((header[1] ^ header[3]) << 8) & 0xFF00);
-            c.setStoredLength(length);
-        } else if (in.readableBytes() >= c.getStoredLength()) {
-            final byte[] data = new byte[c.getStoredLength()];
+            client.setStoredLength(length);
+        } else if (in.readableBytes() >= client.getStoredLength()) {
+            final byte[] data = new byte[client.getStoredLength()];
             in.readBytes(data);
-            c.setStoredLength(-1);
+            client.setStoredLength(-1);
 
             MapleCrypto.crypt(data, iv);
             ShandaCrypto.decrypt(data);
-            c.setRecvIv(IGCipher.innoHash(iv));
+            client.setRecvIv(IGCipher.innoHash(iv));
 
             final InPacket inPacket = new NioBufferInPacket(data);
             out.add(inPacket);

--- a/src/main/java/kinoko/server/node/Client.java
+++ b/src/main/java/kinoko/server/node/Client.java
@@ -58,18 +58,12 @@ public final class Client extends NettyClient {
         super.close();
         if (user == null) {
             if (account != null) {
-                try (var lockedAccount = account.acquire()) {
-                    DatabaseManager.accountAccessor().saveAccount(account);
-                }
+                DatabaseManager.accountAccessor().saveAccount(account);
             }
         } else if (!user.isInTransfer()) {
-            try (var locked = user.acquire()) {
-                try (var lockedAccount = account.acquire()) {
-                    user.logout(true);
-                    DatabaseManager.accountAccessor().saveAccount(account);
-                    DatabaseManager.characterAccessor().saveCharacter(user.getCharacterData());
-                }
-            }
+            user.logout(true);
+            DatabaseManager.accountAccessor().saveAccount(account);
+            DatabaseManager.characterAccessor().saveCharacter(user.getCharacterData());
         }
         getServerNode().removeClient(this);
         account = null;

--- a/src/main/java/kinoko/server/node/GameExecutor.java
+++ b/src/main/java/kinoko/server/node/GameExecutor.java
@@ -1,0 +1,41 @@
+package kinoko.server.node;
+
+import kinoko.util.Lockable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public final class GameExecutor implements Lockable<GameExecutor> {
+    private static final Logger log = LogManager.getLogger(GameExecutor.class);
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final Lock lock = new ReentrantLock();
+
+    public void submit(Runnable runnable) {
+        executor.submit(() -> {
+            try (var locked = acquire()) {
+                runnable.run();
+            } catch (Exception e) {
+                log.error("Exception caught during execution : {}", e, e);
+                e.printStackTrace();
+            }
+        });
+    }
+
+    public void shutdown() {
+        executor.shutdown();
+    }
+
+    @Override
+    public void lock() {
+        lock.lock();
+    }
+
+    @Override
+    public void unlock() {
+        lock.unlock();
+    }
+}

--- a/src/main/java/kinoko/world/field/AffectedAreaPool.java
+++ b/src/main/java/kinoko/world/field/AffectedAreaPool.java
@@ -48,17 +48,13 @@ public final class AffectedAreaPool extends FieldObjectPool<AffectedArea> {
             if (affectedArea.getInterval() != 0 && counter % affectedArea.getInterval() == 0) {
                 switch (affectedArea.getType()) {
                     case UserSkill -> field.getMobPool().forEach((mob) -> {
-                        try (var lockedMob = mob.acquire()) {
-                            if (mob.getHp() > 0 && affectedArea.getRect().isInsideRect(mob.getX(), mob.getY())) {
-                                affectedArea.handleMobInside(lockedMob);
-                            }
+                        if (mob.getHp() > 0 && affectedArea.getRect().isInsideRect(mob.getX(), mob.getY())) {
+                            affectedArea.handleMobInside(mob);
                         }
                     });
                     case MobSkill, Buff, BlessedMist -> field.getUserPool().forEach((user) -> {
-                        try (var locked = user.acquire()) {
-                            if (user.getHp() > 0 && affectedArea.getRect().isInsideRect(user.getX(), user.getY())) {
-                                affectedArea.handleUserInside(locked);
-                            }
+                        if (user.getHp() > 0 && affectedArea.getRect().isInsideRect(user.getX(), user.getY())) {
+                            affectedArea.handleUserInside(user);
                         }
                     });
                 }

--- a/src/main/java/kinoko/world/field/Field.java
+++ b/src/main/java/kinoko/world/field/Field.java
@@ -272,10 +272,8 @@ public final class Field {
                 });
                 final PortalInfo defaultPortal = returnField.getPortalById(0).orElse(PortalInfo.EMPTY);
                 userPool.forEach((user) -> {
-                    try (var locked = user.acquire()) {
-                        final PortalInfo portalInfo = returnField.getRandomStartPoint().orElse(defaultPortal);
-                        locked.get().warp(returnField, portalInfo, false, false);
-                    }
+                    final PortalInfo portalInfo = returnField.getRandomStartPoint().orElse(defaultPortal);
+                    user.warp(returnField, portalInfo, false, false);
                 });
                 instance.getChannelServerNode().removeInstance(instance);
             }

--- a/src/main/java/kinoko/world/field/ReactorPool.java
+++ b/src/main/java/kinoko/world/field/ReactorPool.java
@@ -49,12 +49,10 @@ public final class ReactorPool extends FieldObjectPool<Reactor> {
         if (HenesysPQ.PRIMROSE_REACTORS.contains(reactor.getTemplateId())) {
             final Optional<Reactor> moonReactorResult = getByTemplateId(HenesysPQ.MOON_REACTOR);
             if (moonReactorResult.isPresent()) {
-                try (var lockedReactor = moonReactorResult.get().acquire()) {
-                    final Reactor moonReactor = lockedReactor.get();
-                    if (!moonReactor.isLastState()) {
-                        moonReactor.setState(moonReactor.getState() + 1);
-                        hitReactor(user, moonReactor, 0);
-                    }
+                final Reactor moonReactor = moonReactorResult.get();
+                if (!moonReactor.isLastState()) {
+                    moonReactor.setState(moonReactor.getState() + 1);
+                    hitReactor(user, moonReactor, 0);
                 }
             }
         }
@@ -64,16 +62,14 @@ public final class ReactorPool extends FieldObjectPool<Reactor> {
         final var iter = hitReactors.entrySet().iterator();
         while (iter.hasNext()) {
             final Map.Entry<Reactor, Instant> entry = iter.next();
-            try (var lockedReactor = entry.getKey().acquire()) {
-                final Reactor reactor = lockedReactor.get();
-                // Check reactor time and reset reactor
-                if (now.isBefore(entry.getValue())) {
-                    continue;
-                }
-                iter.remove();
-                reactor.reset(reactor.getX(), reactor.getY(), 0);
-                field.broadcastPacket(FieldPacket.reactorChangeState(reactor, 0, 0, 0));
+            final Reactor reactor = entry.getKey();
+            // Check reactor time and reset reactor
+            if (now.isBefore(entry.getValue())) {
+                continue;
             }
+            iter.remove();
+            reactor.reset(reactor.getX(), reactor.getY(), 0);
+            field.broadcastPacket(FieldPacket.reactorChangeState(reactor, 0, 0, 0));
         }
     }
 }

--- a/src/main/java/kinoko/world/field/TownPortalPool.java
+++ b/src/main/java/kinoko/world/field/TownPortalPool.java
@@ -1,7 +1,6 @@
 package kinoko.world.field;
 
 import kinoko.packet.field.FieldPacket;
-import kinoko.packet.world.MessagePacket;
 import kinoko.provider.map.FieldOption;
 import kinoko.server.field.InstanceFieldStorage;
 import kinoko.server.packet.OutPacket;

--- a/src/main/java/kinoko/world/field/UserPool.java
+++ b/src/main/java/kinoko/world/field/UserPool.java
@@ -44,24 +44,22 @@ public final class UserPool extends FieldObjectPool<User> {
     public synchronized void addUser(User user) {
         // Update client with existing users in pool
         forEach((existingUser) -> {
-            try (var locked = existingUser.acquire()) {
-                user.write(UserPacket.userEnterField(locked.get()));
-                for (Pet pet : existingUser.getPets()) {
-                    user.write(PetPacket.petActivated(existingUser, pet));
+            user.write(UserPacket.userEnterField(user));
+            for (Pet pet : existingUser.getPets()) {
+                user.write(PetPacket.petActivated(existingUser, pet));
+            }
+            for (List<Summoned> summonedList : existingUser.getSummoned().values()) {
+                for (Summoned summoned : summonedList) {
+                    user.write(SummonedPacket.summonedEnterField(existingUser, summoned));
                 }
-                for (List<Summoned> summonedList : existingUser.getSummoned().values()) {
-                    for (Summoned summoned : summonedList) {
-                        user.write(SummonedPacket.summonedEnterField(existingUser, summoned));
-                    }
-                }
-                if (existingUser.getDragon() != null) {
-                    user.write(DragonPacket.dragonEnterField(existingUser, existingUser.getDragon()));
-                }
-                if (existingUser.getOpenGate() != null) {
-                    user.write(FieldPacket.openGateCreated(existingUser, existingUser.getOpenGate(), false));
-                    if (existingUser.getOpenGate().getSecondGate() != null) {
-                        user.write(FieldPacket.openGateCreated(existingUser, existingUser.getOpenGate().getSecondGate(), false));
-                    }
+            }
+            if (existingUser.getDragon() != null) {
+                user.write(DragonPacket.dragonEnterField(existingUser, existingUser.getDragon()));
+            }
+            if (existingUser.getOpenGate() != null) {
+                user.write(FieldPacket.openGateCreated(existingUser, existingUser.getOpenGate(), false));
+                if (existingUser.getOpenGate().getSecondGate() != null) {
+                    user.write(FieldPacket.openGateCreated(existingUser, existingUser.getOpenGate().getSecondGate(), false));
                 }
             }
         });
@@ -93,10 +91,8 @@ public final class UserPool extends FieldObjectPool<User> {
 
         // Update party
         forEachPartyMember(user, (member) -> {
-            try (var lockedMember = member.acquire()) {
-                user.write(UserRemote.receiveHp(lockedMember.get()));
-                lockedMember.get().write(UserRemote.receiveHp(user));
-            }
+            user.write(UserRemote.receiveHp(member));
+            member.write(UserRemote.receiveHp(user));
         });
 
         // Create field objects for user
@@ -208,63 +204,43 @@ public final class UserPool extends FieldObjectPool<User> {
 
     public void updateUsers(Instant now) {
         for (User user : getObjects()) {
-            try (var locked = user.acquire()) {
-                // Handle CTS updates on tick
-                SkillProcessor.processUpdate(locked, now);
-                // Expire temporary stat
-                user.resetTemporaryStat((cts, option) -> now.isAfter(option.getExpireTime()));
-                // Expire skill cooltimes
-                final Set<Integer> resetCooltimes = user.getSkillManager().expireSkillCooltime(now);
-                for (int skillId : resetCooltimes) {
-                    user.write(UserLocal.skillCooltimeSet(skillId, 0));
+            // Handle CTS updates on tick
+            SkillProcessor.processUpdate(user, now);
+            // Expire temporary stat
+            user.resetTemporaryStat((cts, option) -> now.isAfter(option.getExpireTime()));
+            // Expire skill cooltimes
+            final Set<Integer> resetCooltimes = user.getSkillManager().expireSkillCooltime(now);
+            for (int skillId : resetCooltimes) {
+                user.write(UserLocal.skillCooltimeSet(skillId, 0));
+            }
+            // Expire summoned
+            user.removeSummoned((summoned) -> now.isAfter(summoned.getExpireTime()));
+            // Expire town portal
+            final TownPortal townPortal = user.getTownPortal();
+            if (townPortal != null) {
+                if (townPortal.getExpireTime().isBefore(now)) {
+                    townPortal.destroy();
+                    user.setTownPortal(null);
+                    user.write(WvsContext.resetTownPortal());
+                    user.write(MessagePacket.skillExpire(townPortal.getSkillId()));
+                    user.getConnectedServer().notifyUserUpdate(user);
                 }
-                // Expire summoned
-                user.removeSummoned((summoned) -> now.isAfter(summoned.getExpireTime()));
-                // Expire town portal
-                final TownPortal townPortal = user.getTownPortal();
-                if (townPortal != null) {
-                    if (townPortal.getExpireTime().isBefore(now)) {
-                        townPortal.destroy();
-                        user.setTownPortal(null);
-                        user.write(WvsContext.resetTownPortal());
-                        user.write(MessagePacket.skillExpire(townPortal.getSkillId()));
-                        user.getConnectedServer().notifyUserUpdate(user);
-                    }
+            }
+            // Expire open gate
+            final OpenGate openGate = user.getOpenGate();
+            if (openGate != null) {
+                if (openGate.getExpireTime().isBefore(now)) {
+                    openGate.destroy();
+                    user.setOpenGate(null);
                 }
-                // Expire open gate
-                final OpenGate openGate = user.getOpenGate();
-                if (openGate != null) {
-                    if (openGate.getExpireTime().isBefore(now)) {
-                        openGate.destroy();
-                        user.setOpenGate(null);
-                    }
-                }
-                // Expire items
-                if (now.isAfter(user.getNextCheckItemExpire())) {
-                    user.setNextCheckItemExpire(now.plus(ServerConfig.ITEM_EXPIRE_INTERVAL, ChronoUnit.SECONDS));
-                    boolean itemExpired = false;
-                    final InventoryManager im = user.getInventoryManager();
-                    for (InventoryType inventoryType : List.of(InventoryType.EQUIPPED, InventoryType.EQUIP, InventoryType.CONSUME, InventoryType.INSTALL, InventoryType.ETC)) {
-                        final var iter = im.getInventoryByType(inventoryType).getItems().entrySet().iterator();
-                        while (iter.hasNext()) {
-                            final var entry = iter.next();
-                            final int position = entry.getKey();
-                            final Item item = entry.getValue();
-                            if (item.getDateExpire() == null || now.isBefore(item.getDateExpire())) {
-                                continue;
-                            }
-                            // Remove item from inventory
-                            iter.remove();
-                            user.write(WvsContext.inventoryOperation(InventoryOperation.delItem(
-                                    inventoryType == InventoryType.EQUIPPED ? InventoryType.EQUIP : inventoryType,
-                                    inventoryType == InventoryType.EQUIPPED ? -position : position
-                            ), false));
-                            user.write(MessagePacket.generalItemExpire(item.getItemId()));
-                            itemExpired = true;
-                        }
-                    }
-                    // Expire cash items and pets
-                    final var iter = im.getCashInventory().getItems().entrySet().iterator();
+            }
+            // Expire items
+            if (now.isAfter(user.getNextCheckItemExpire())) {
+                user.setNextCheckItemExpire(now.plus(ServerConfig.ITEM_EXPIRE_INTERVAL, ChronoUnit.SECONDS));
+                boolean itemExpired = false;
+                final InventoryManager im = user.getInventoryManager();
+                for (InventoryType inventoryType : List.of(InventoryType.EQUIPPED, InventoryType.EQUIP, InventoryType.CONSUME, InventoryType.INSTALL, InventoryType.ETC)) {
+                    final var iter = im.getInventoryByType(inventoryType).getItems().entrySet().iterator();
                     while (iter.hasNext()) {
                         final var entry = iter.next();
                         final int position = entry.getKey();
@@ -272,27 +248,45 @@ public final class UserPool extends FieldObjectPool<User> {
                         if (item.getDateExpire() == null || now.isBefore(item.getDateExpire())) {
                             continue;
                         }
-                        if (item.getItemType() == ItemType.PET) {
-                            // Set pet as expired - FileTime.DEFAULT_TIME should be encoded to turn them into dolls
-                            item.setDateExpire(null);
-                            user.write(WvsContext.inventoryOperation(InventoryOperation.newItem(InventoryType.CASH, position, item), false));
-                            // Deactivate pet if required
-                            final Optional<Integer> petIndexResult = user.getPetIndex(item.getItemSn());
-                            if (petIndexResult.isPresent() && user.removePet(petIndexResult.get())) {
-                                user.getField().broadcastPacket(PetPacket.petDeactivated(user, petIndexResult.get(), 2)); // The pet's magical time has run out and so it has turned back into a doll.
-                            }
-                        } else {
-                            // Remove item from inventory
-                            iter.remove();
-                            user.write(WvsContext.inventoryOperation(InventoryOperation.delItem(InventoryType.CASH, position), false));
-                            user.write(MessagePacket.cashItemExpire(item.getItemId()));
-                        }
+                        // Remove item from inventory
+                        iter.remove();
+                        user.write(WvsContext.inventoryOperation(InventoryOperation.delItem(
+                                inventoryType == InventoryType.EQUIPPED ? InventoryType.EQUIP : inventoryType,
+                                inventoryType == InventoryType.EQUIPPED ? -position : position
+                        ), false));
+                        user.write(MessagePacket.generalItemExpire(item.getItemId()));
                         itemExpired = true;
                     }
-                    // Validate stat
-                    if (itemExpired) {
-                        user.validateStat();
+                }
+                // Expire cash items and pets
+                final var iter = im.getCashInventory().getItems().entrySet().iterator();
+                while (iter.hasNext()) {
+                    final var entry = iter.next();
+                    final int position = entry.getKey();
+                    final Item item = entry.getValue();
+                    if (item.getDateExpire() == null || now.isBefore(item.getDateExpire())) {
+                        continue;
                     }
+                    if (item.getItemType() == ItemType.PET) {
+                        // Set pet as expired - FileTime.DEFAULT_TIME should be encoded to turn them into dolls
+                        item.setDateExpire(null);
+                        user.write(WvsContext.inventoryOperation(InventoryOperation.newItem(InventoryType.CASH, position, item), false));
+                        // Deactivate pet if required
+                        final Optional<Integer> petIndexResult = user.getPetIndex(item.getItemSn());
+                        if (petIndexResult.isPresent() && user.removePet(petIndexResult.get())) {
+                            user.getField().broadcastPacket(PetPacket.petDeactivated(user, petIndexResult.get(), 2)); // The pet's magical time has run out and so it has turned back into a doll.
+                        }
+                    } else {
+                        // Remove item from inventory
+                        iter.remove();
+                        user.write(WvsContext.inventoryOperation(InventoryOperation.delItem(InventoryType.CASH, position), false));
+                        user.write(MessagePacket.cashItemExpire(item.getItemId()));
+                    }
+                    itemExpired = true;
+                }
+                // Validate stat
+                if (itemExpired) {
+                    user.validateStat();
                 }
             }
         }

--- a/src/main/java/kinoko/world/field/affectedarea/AffectedArea.java
+++ b/src/main/java/kinoko/world/field/affectedarea/AffectedArea.java
@@ -7,7 +7,6 @@ import kinoko.provider.skill.SkillStat;
 import kinoko.server.ServerConfig;
 import kinoko.server.packet.OutPacket;
 import kinoko.util.Encodable;
-import kinoko.util.Locked;
 import kinoko.util.Rect;
 import kinoko.world.field.FieldObject;
 import kinoko.world.field.FieldObjectImpl;
@@ -85,8 +84,7 @@ public final class AffectedArea extends FieldObjectImpl implements Encodable {
         return expireTime;
     }
 
-    public void handleUserInside(Locked<User> locked) {
-        final User user = locked.get();
+    public void handleUserInside(User user) {
         switch (skillId) {
             case Evan.RECOVERY_AURA -> {
                 final int partyId = ((User) owner).getPartyId();
@@ -105,8 +103,7 @@ public final class AffectedArea extends FieldObjectImpl implements Encodable {
         }
     }
 
-    public void handleMobInside(Locked<Mob> lockedMob) {
-        final Mob mob = lockedMob.get();
+    public void handleMobInside(Mob mob) {
         switch (skillId) {
             case Magician.POISON_MIST, BlazeWizard.FLAME_GEAR, NightWalker.POISON_BOMB -> {
                 if (mob.getHp() == 1 || mob.getMobStat().hasBurnedInfo(owner.getId(), skillId)) {

--- a/src/main/java/kinoko/world/field/summoned/Summoned.java
+++ b/src/main/java/kinoko/world/field/summoned/Summoned.java
@@ -2,7 +2,6 @@ package kinoko.world.field.summoned;
 
 import kinoko.provider.map.Foothold;
 import kinoko.provider.skill.SkillInfo;
-import kinoko.util.Lockable;
 import kinoko.util.Rect;
 import kinoko.world.field.Field;
 import kinoko.world.field.life.Life;
@@ -10,11 +9,8 @@ import kinoko.world.user.AvatarLook;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
-public final class Summoned extends Life implements Lockable<Summoned> {
-    private final Lock lock = new ReentrantLock();
+public final class Summoned extends Life {
     private final int skillId;
     private final int skillLevel;
     private final SummonedMoveAbility moveAbility;
@@ -124,16 +120,6 @@ public final class Summoned extends Life implements Lockable<Summoned> {
                 ", hp=" + hp +
                 ", teslaCoilState=" + teslaCoilState +
                 '}';
-    }
-
-    @Override
-    public void lock() {
-        lock.lock();
-    }
-
-    @Override
-    public void unlock() {
-        lock.unlock();
     }
 
     public static Summoned from(SkillInfo si, int slv, SummonedMoveAbility moveAbility, SummonedAssistType assistType) {

--- a/src/main/java/kinoko/world/job/resistance/Citizen.java
+++ b/src/main/java/kinoko/world/job/resistance/Citizen.java
@@ -65,35 +65,33 @@ public final class Citizen extends SkillProcessor {
                     user.write(UserLocal.effect(Effect.skillUseInfo(skillId, slv, user.getLevel(), 2))); // Monster cannot be captured.
                     return;
                 }
-                try (var lockedMob = captureResult.get().acquire()) {
-                    final Mob mob = lockedMob.get();
-                    final int templateId = mob.getTemplateId();
-                    // Should implement all client side checks in CUserLocal::DoActiveSkill_MobCapture
-                    final List<Integer> capturedMobs = user.getWildHunterInfo().getCapturedMobs();
-                    if (mob.isBoss() || mob.getLevel() > user.getLevel() || capturedMobs.contains(templateId)) {
-                        user.write(UserLocal.effect(Effect.skillUseInfo(skillId, slv, user.getLevel(), 2))); // Monster cannot be captured.
-                        return;
-                    }
-                    // Check hp below 50%
-                    final int percentage = (int) ((double) mob.getHp() / mob.getMaxHp() * 100.0);
-                    if (percentage > si.getValue(SkillStat.x, slv)) {
-                        user.write(UserLocal.effect(Effect.skillUseInfo(skillId, slv, user.getLevel(), 1))); // Capture failed. Monster HP too high.
-                        return;
-                    }
-                    // Capture success
-                    user.write(UserLocal.effect(Effect.skillUseInfo(skillId, slv, user.getLevel(), 0))); // Monster successfully captured.
-                    field.getMobPool().removeMob(mob, MobLeaveType.ETC);
-                    // Update WildHunterInfo
-                    if (GameConstants.isJaguarMob(templateId)) {
-                        user.getWildHunterInfo().setRidingType((templateId % 10) + 1);
-                    } else {
-                        capturedMobs.add(templateId);
-                        if (capturedMobs.size() > 5) {
-                            capturedMobs.removeFirst();
-                        }
-                    }
-                    user.write(WvsContext.wildHunterInfo(user.getWildHunterInfo()));
+                final Mob capturedMob = captureResult.get();
+                final int templateId = capturedMob.getTemplateId();
+                // Should implement all client side checks in CUserLocal::DoActiveSkill_MobCapture
+                final List<Integer> capturedMobs = user.getWildHunterInfo().getCapturedMobs();
+                if (capturedMob.isBoss() || capturedMob.getLevel() > user.getLevel() || capturedMobs.contains(templateId)) {
+                    user.write(UserLocal.effect(Effect.skillUseInfo(skillId, slv, user.getLevel(), 2))); // Monster cannot be captured.
+                    return;
                 }
+                // Check hp below 50%
+                final int percentage = (int) ((double) capturedMob.getHp() / capturedMob.getMaxHp() * 100.0);
+                if (percentage > si.getValue(SkillStat.x, slv)) {
+                    user.write(UserLocal.effect(Effect.skillUseInfo(skillId, slv, user.getLevel(), 1))); // Capture failed. Monster HP too high.
+                    return;
+                }
+                // Capture success
+                user.write(UserLocal.effect(Effect.skillUseInfo(skillId, slv, user.getLevel(), 0))); // Monster successfully captured.
+                field.getMobPool().removeMob(capturedMob, MobLeaveType.ETC);
+                // Update WildHunterInfo
+                if (GameConstants.isJaguarMob(templateId)) {
+                    user.getWildHunterInfo().setRidingType((templateId % 10) + 1);
+                } else {
+                    capturedMobs.add(templateId);
+                    if (capturedMobs.size() > 5) {
+                        capturedMobs.removeFirst();
+                    }
+                }
+                user.write(WvsContext.wildHunterInfo(user.getWildHunterInfo()));
                 return;
             case Citizen.CALL_OF_THE_HUNTER:
                 // Remove from captured mob list and update client

--- a/src/main/java/kinoko/world/job/resistance/Mechanic.java
+++ b/src/main/java/kinoko/world/job/resistance/Mechanic.java
@@ -192,14 +192,12 @@ public final class Mechanic extends SkillProcessor {
                 user.addSummoned(accelerationBot);
                 // Initial effect
                 field.getMobPool().forEach((mob) -> {
-                    try (var lockedMob = mob.acquire()) {
-                        if (!mob.isBoss()) {
-                            mob.setTemporaryStat(Map.of(
-                                    MobTemporaryStat.Speed, MobStatOption.of(si.getValue(SkillStat.x, slv), skillId, 0),
-                                    MobTemporaryStat.PDR, MobStatOption.of(si.getValue(SkillStat.y, slv), skillId, 0),
-                                    MobTemporaryStat.MDR, MobStatOption.of(si.getValue(SkillStat.y, slv), skillId, 0)
-                            ), 0);
-                        }
+                    if (!mob.isBoss()) {
+                        mob.setTemporaryStat(Map.of(
+                                MobTemporaryStat.Speed, MobStatOption.of(si.getValue(SkillStat.x, slv), skillId, 0),
+                                MobTemporaryStat.PDR, MobStatOption.of(si.getValue(SkillStat.y, slv), skillId, 0),
+                                MobTemporaryStat.MDR, MobStatOption.of(si.getValue(SkillStat.y, slv), skillId, 0)
+                        ), 0);
                     }
                 });
                 // Set spawn modifier
@@ -282,10 +280,8 @@ public final class Mechanic extends SkillProcessor {
     public static void handleRemoveAccelerationBot(Summoned summoned) {
         summoned.getField().getMobSpawnModifiers().remove(summoned.getId());
         summoned.getField().getMobPool().forEach((mob) -> {
-            try (var lockedMob = mob.acquire()) {
-                if (!mob.isBoss()) {
-                    mob.resetTemporaryStat(summoned.getSkillId());
-                }
+            if (!mob.isBoss()) {
+                mob.resetTemporaryStat(summoned.getSkillId());
             }
         });
     }

--- a/src/main/java/kinoko/world/job/resistance/WildHunter.java
+++ b/src/main/java/kinoko/world/job/resistance/WildHunter.java
@@ -127,10 +127,8 @@ public final class WildHunter extends SkillProcessor {
                     log.error("Could not resolve target mob ID : {} for jaguar-oshi skill", targetMobId);
                     return;
                 }
-                try (var lockedMob = targetResult.get().acquire()) {
-                    final Mob mob = lockedMob.get();
-                    mob.damage(user, mob.getHp(), 0, MobLeaveType.SWALLOW);
-                }
+                final Mob mob = targetResult.get();
+                mob.damage(user, mob.getHp(), 0, MobLeaveType.SWALLOW);
                 return;
             case JAGUAR_OSHI_DIGESTED:
                 user.resetTemporaryStat(Set.of(CharacterTemporaryStat.Swallow_Mob, CharacterTemporaryStat.Swallow_Template));

--- a/src/main/java/kinoko/world/skill/AttackInfo.java
+++ b/src/main/java/kinoko/world/skill/AttackInfo.java
@@ -1,6 +1,5 @@
 package kinoko.world.skill;
 
-import kinoko.util.Locked;
 import kinoko.world.field.mob.Mob;
 
 import java.util.Arrays;
@@ -19,7 +18,7 @@ public final class AttackInfo {
     public int[] damage = new int[15];
 
     public long[] random;
-    public Locked<Mob> lockedMob;
+    public Mob mob;
 
     @Override
     public String toString() {
@@ -34,7 +33,7 @@ public final class AttackInfo {
                 ", critical=" + Arrays.toString(critical) +
                 ", damage=" + Arrays.toString(damage) +
                 ", random=" + Arrays.toString(random) +
-                ", lockedMob=" + lockedMob +
+                ", mob=" + mob +
                 '}';
     }
 }

--- a/src/main/java/kinoko/world/skill/Skill.java
+++ b/src/main/java/kinoko/world/skill/Skill.java
@@ -70,11 +70,9 @@ public final class Skill {
             if (userResult.isEmpty()) {
                 continue;
             }
-            try (var locked = userResult.get().acquire()) {
-                final User user = locked.get();
-                if (user.getHp() > 0) {
-                    consumer.accept(user);
-                }
+            final User user = userResult.get();
+            if (user.getHp() > 0) {
+                consumer.accept(user);
             }
         }
     }
@@ -88,11 +86,9 @@ public final class Skill {
             if (mobResult.isEmpty()) {
                 continue;
             }
-            try (var lockedMob = mobResult.get().acquire()) {
-                final Mob mob = lockedMob.get();
-                if (mob.getHp() > 0) {
-                    consumer.accept(mob);
-                }
+            final Mob mob = mobResult.get();
+            if (mob.getHp() > 0) {
+                consumer.accept(mob);
             }
         }
     }

--- a/src/main/java/kinoko/world/user/Account.java
+++ b/src/main/java/kinoko/world/user/Account.java
@@ -1,14 +1,10 @@
 package kinoko.world.user;
 
-import kinoko.util.Lockable;
 import kinoko.world.item.Trunk;
 
 import java.util.List;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
-public final class Account implements Lockable<Account> {
-    private final Lock lock = new ReentrantLock();
+public final class Account {
     private final int id;
     private final String username;
     private int slotCount;
@@ -123,15 +119,5 @@ public final class Account implements Lockable<Account> {
     public boolean canSelectCharacter(int characterId) {
         return getCharacterList() != null &&
                 getCharacterList().stream().anyMatch(avatarData -> avatarData.getCharacterId() == characterId);
-    }
-
-    @Override
-    public void lock() {
-        lock.lock();
-    }
-
-    @Override
-    public void unlock() {
-        lock.unlock();
     }
 }

--- a/src/main/java/kinoko/world/user/User.java
+++ b/src/main/java/kinoko/world/user/User.java
@@ -20,6 +20,7 @@ import kinoko.server.dialog.miniroom.MiniRoom;
 import kinoko.server.guild.GuildRank;
 import kinoko.server.node.ChannelServerNode;
 import kinoko.server.node.Client;
+import kinoko.server.node.ServerExecutor;
 import kinoko.server.packet.OutPacket;
 import kinoko.server.party.PartyRequest;
 import kinoko.util.BitFlag;
@@ -744,6 +745,16 @@ public final class User extends Life {
         setFoothold(destination.getFootholdBelow(x, y).map(Foothold::getSn).orElse(0));
         getCharacterStat().setPosMap(destination.getFieldId());
         getCharacterStat().setPortal((byte) portalId);
+        if (isMigrate) {
+            completeWarp(destination, true, isRevive);
+        } else {
+            ServerExecutor.submit(destination, () -> {
+                completeWarp(destination, false, isRevive);
+            });
+        }
+    }
+
+    private void completeWarp(Field destination, boolean isMigrate, boolean isRevive) {
         write(StagePacket.setField(this, getChannelId(), isMigrate, isRevive));
         destination.addUser(this);
         getConnectedServer().notifyUserUpdate(this);

--- a/src/main/java/kinoko/world/user/stat/CalcDamage.java
+++ b/src/main/java/kinoko/world/user/stat/CalcDamage.java
@@ -8,7 +8,6 @@ import kinoko.provider.skill.ElementAttribute;
 import kinoko.provider.skill.SkillInfo;
 import kinoko.provider.skill.SkillStat;
 import kinoko.server.header.OutHeader;
-import kinoko.util.Locked;
 import kinoko.util.Rand32;
 import kinoko.world.GameConstants;
 import kinoko.world.field.mob.Mob;
@@ -67,12 +66,10 @@ public final class CalcDamage {
 
     // DAMAGE CALC -----------------------------------------------------------------------------------------------------
 
-    public static void calcPDamage(Locked<User> locked, Locked<Mob> lockedMob, Attack attack, AttackInfo ai) {
+    public static void calcPDamage(User user, Mob mob, Attack attack, AttackInfo ai) {
         // CalcDamage::PDamage
-        final User user = locked.get();
         final SecondaryStat ss = user.getSecondaryStat();
         final PassiveSkillData psd = user.getPassiveSkillData();
-        final Mob mob = lockedMob.get();
         final MobStat ms = mob.getMobStat();
         final int skillId = attack.skillId;
         final int noviceSkill = Math.max(skillId - (JobConstants.getNoviceSkillRootFromJob(user.getJob()) * 1000), 0);
@@ -208,11 +205,9 @@ public final class CalcDamage {
         user.getCalcDamage().setNextAttackCritical(false);
     }
 
-    public static void calcMDamage(Locked<User> locked, Locked<Mob> lockedMob, Attack attack, AttackInfo ai) {
+    public static void calcMDamage(User user, Mob mob, Attack attack, AttackInfo ai) {
         // CalcDamage::MDamage
-        final User user = locked.get();
         final SecondaryStat ss = user.getSecondaryStat();
-        final Mob mob = lockedMob.get();
         final MobStat ms = mob.getMobStat();
         final int skillId = attack.skillId;
         final int noviceSkill = Math.max(skillId - (JobConstants.getNoviceSkillRootFromJob(user.getJob()) * 1000), 0);


### PR DESCRIPTION
Packets received from the users in the same field are basically processed in a single-threaded manner, and the field objects are also updated in the same thread. This should allow for removal of locks from all field objects without compromising thread safety.

Only apparent issue is the script executor, which currently run each script inside a virtual thread to allow for pausing and resuming its execution while waiting for user input. To consider when implementing #29 
- Update : this was handled by holding the lock on the field executor inside the virtual thread execution and returning it while waiting for user input