### PR TITLE
Added GMS-like level restriction to Sleepywood portal

### DIFF
--- a/src/main/java/kinoko/script/continent/VictoriaIsland.java
+++ b/src/main/java/kinoko/script/continent/VictoriaIsland.java
@@ -214,6 +214,12 @@ public final class VictoriaIsland extends ScriptHandler {
     public static void enter_VDS(ScriptManager sm) {
         // Sleepywood : Sleepywood (105000000)
         //   east00 (1759, 312)
+        final int playerLevel = sm.getUser().getLevel();
+        if (playerLevel < 50) {
+            sm.scriptProgressMessage("You cannot enter, because you do not meet the level requirement.");
+            sm.message("You must be Lv. 50 or above to enter this area.");
+            return;
+        }
         sm.playPortalSE();
         sm.warp(105010000, "west00"); // Swamp : Silent Swamp
     }


### PR DESCRIPTION
This portal checks if the player's level is below 50. If it is, it prevents the player from moving through the portal and notifies them.

The text can be found here: https://youtu.be/6jhpC2Cjt-o?si=spJEjURPkL9NK6TK&t=252