### PR TITLE
Add reward data for Serpent (1150002)

### DIFF
--- a/data/reward/1150002.yaml
+++ b/data/reward/1150002.yaml
@@ -1,0 +1,19 @@
+# Serpent (1150002)
+
+# bc.hidden-street.net suggests these should drop: Red Potion, Orange Potion, White Potion, Blue Potion,
+#   Ice Jeans, Studded Polearm, Yellow Arianne (F), Dark Nightshift (M)
+#   NOTE: hidden-street doesn't include serpent tail as an etc drop, but it seems obvious that it should be.
+#   See the item detail page for before chaos hidden-street, it appropriately shows the associated quests:
+#   https://bc.hidden-street.net/items/leftover/serpent-tail
+
+rewards:
+  - [ 0, 22, 33, 0.600000 ] # Copypasta from Strange Sign (1150001)
+  - [ 1062000, 1, 1, 0.000100 ] # Ice Jeans
+  - [ 1442007, 1, 1, 0.000100 ] # Studded Polearm
+  - [ 1041026, 1, 1, 0.000100 ] # Yellow Arianne
+  - [ 1040034, 1, 1, 0.000100 ] # Dark Nightshift
+  - [ 2000000, 1, 1, 0.010000 ] # Red Potion
+  - [ 2000001, 1, 1, 0.010000 ] # Orange Potion
+  - [ 2000002, 1, 1, 0.010000 ] # White Potion
+  - [ 2000003, 1, 1, 0.010000 ] # Blue Potion
+  - [ 4000600, 1, 1, 0.400000 ] # Serpent Tail


### PR DESCRIPTION
# Background

This addresssssses (🐍) [issue 56](https://github.com/iw2d/kinoko/issues/56) for missing serpent data blocking some edelstein quests.

# Testing

`docker compose up -d --force-recreate server`, then serpents were dropping tails, and quests could be finished.

**Serpent Tail Dropping**

![serpent_tail_drop](https://github.com/user-attachments/assets/a82b5234-5d32-4230-a84b-f27ff306780c)

**Quests Complete**

<img width="229" height="244" alt="image" src="https://github.com/user-attachments/assets/b4edbe56-a1ec-45d0-bdd3-7cb7465e5ca2" />
